### PR TITLE
writer: Leaf directories: Find best base zoom

### DIFF
--- a/python/pmtiles/writer.py
+++ b/python/pmtiles/writer.py
@@ -2,6 +2,7 @@ import gzip
 import itertools
 import json
 from contextlib import contextmanager
+from collections import defaultdict
 
 @contextmanager
 def write(fname):
@@ -19,6 +20,7 @@ class Writer:
         self.tiles = []
         self.hash_to_offset = {}
         self.leaves = []
+        self.zoom_counts = defaultdict(int)
 
     def write_tile(self,z,x,y,data):
         # if the tile is GZIP-encoded, it won't work with range queries
@@ -34,6 +36,7 @@ class Writer:
             self.tiles.append((z,x,y,self.offset,len(data)))
             self.hash_to_offset[hsh] = self.offset
             self.offset = self.offset + len(data)
+            self.zoom_counts[z] += 1
 
     def write_entry(self,entry):
         self.f.write(entry[0].to_bytes(1,byteorder='little'))
@@ -69,17 +72,24 @@ class Writer:
             leafdir_tiles = []
             leafdir_len = 0
 
+            # Find best base zoom to avoid extra indirection for as many tiles as we can
+            base_zoom = 7
+            n_so_far = sum(self.zoom_counts[z] for z in range(0,8))
+            while n_so_far + self.zoom_counts[base_zoom+1] < 21845:
+                n_so_far += self.zoom_counts[base_zoom+1]
+                base_zoom += 1
+
             def by_parent(t):
-                if t[0] >= 7:
-                    level_diff = t[0] - 7
-                    return (7,t[1]//(1 << level_diff),t[2]//(1 << level_diff))
+                if t[0] >= base_zoom:
+                    level_diff = t[0] - base_zoom
+                    return (base_zoom,t[1]//(1 << level_diff),t[2]//(1 << level_diff))
                 else:
                     return (0,t[1]//(1 << t[0]),t[2]//(1 << t[0]))
 
             # TODO optimize order
             self.tiles.sort(key=by_parent)
             for group in itertools.groupby(self.tiles,key=by_parent):
-                if group[0][0] != 7:
+                if group[0][0] != base_zoom:
                     continue
                 entries = list(group[1])
                 if leafdir_len + len(entries) <= 21845:


### PR DESCRIPTION
... to avoid extra indirection for as many tiles as we can

Previously, we hardcoded a "base_zoom = 7", which is only only optimal for a whole world map.
instead "7" is replaced with min zoom that fits all tiles.

I only tested on one example (Bugianen, 152742 tiles) and got the expected base zoom of 14.
```

```sh
sqlite3 Bugianen.mbtiles "SELECT  zoom_level, COUNT(*) FROM tiles GROUP BY zoom_level"
12|448
13|1792
14|7168
15|28672
16|114662

PYTHONPATH=$PWD bin/pmtiles-convert Bugianen.mbtiles optim_Bugianen.pmtiles
Num tiles: 152742
Num unique tiles: 151947
Num leaves: 7168
```

So, this needs more testing.