### PR TITLE
refactor python reader to take a get_bytes function; add reader tests…

### DIFF
--- a/python/bin/pmtiles-show
+++ b/python/bin/pmtiles-show
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from pmtiles.reader import read
+from pmtiles.reader import Reader, MmapSource
 
 if len(sys.argv) <= 1:
     print("Usage: pmtiles-show PMTILES_FILE")
@@ -9,7 +9,8 @@ if len(sys.argv) <= 1:
     print("Usage: pmtiles-show PMTILES_FILE list")
     exit(1)
 
-with read(sys.argv[1]) as reader:
+with open(sys.argv[1],'r+b') as f:
+    reader = Reader(MmapSource(f))
     spec_version = reader.version
     if len(sys.argv) == 2:
         print("spec version: ", spec_version)

--- a/python/test/test_reader.py
+++ b/python/test/test_reader.py
@@ -1,0 +1,32 @@
+import unittest
+from io import BytesIO
+from pmtiles.writer import Writer
+from pmtiles.reader import Reader, MemorySource
+
+
+class TestReader(unittest.TestCase):
+    def test_roundtrip(self):
+        buf = BytesIO()
+        writer = Writer(buf, 7)
+        writer.write_tile(1, 0, 0, b"0")
+        writer.write_tile(1, 0, 1, b"1")
+        writer.write_tile(1, 1, 0, b"2")
+        writer.write_tile(1, 1, 1, b"3")
+        writer.write_tile(2, 0, 0, b"4")
+        writer.write_tile(3, 0, 0, b"5")
+        writer.write_tile(2, 0, 1, b"6")
+        writer.write_tile(3, 0, 2, b"7")
+        writer.finalize({"key": "value"})
+
+        reader = Reader(MemorySource(buf.getvalue()))
+        self.assertEqual(reader.version, 2)
+        self.assertEqual(reader.root_entries, 6)
+        self.assertEqual(reader.metadata["key"], "value")
+        self.assertEqual(reader.get(1, 0, 0), b"0")
+        self.assertEqual(reader.get(1, 0, 1), b"1")
+        self.assertEqual(reader.get(1, 1, 0), b"2")
+        self.assertEqual(reader.get(1, 1, 1), b"3")
+        self.assertEqual(reader.get(2, 0, 0), b"4")
+        self.assertEqual(reader.get(3, 0, 0), b"5")
+        self.assertEqual(reader.get(2, 0, 1), b"6")
+        self.assertEqual(reader.get(3, 0, 2), b"7")


### PR DESCRIPTION
… [#38]

Still todo:
- [ ] refactor reader to use less get_bytes calls, should only make one get_bytes for the header
- [ ] add other Source implementations