### PR TITLE
Improve pmtiles-serve CLI description

### DIFF
--- a/python/bin/pmtiles-serve
+++ b/python/bin/pmtiles-serve
@@ -15,7 +15,7 @@ class ThreadingSimpleServer(ThreadingMixIn, http.server.HTTPServer):
 
 
 parser = argparse.ArgumentParser(
-    description="Convert between PMTiles and other archive formats."
+    description="HTTP server for PMTiles archives."
 )
 parser.add_argument("pmtiles_file", help="PMTiles archive to serve")
 parser.add_argument("port", help="Port to bind to")


### PR DESCRIPTION
Quick fix for the CLI description for `pmtiles-serve`. It looks like it was copy-and-pasted from [`pmtiles-convert`](https://github.com/protomaps/PMTiles/blob/cbc5f190838acafb0c2aca0450fef053eea977aa/python/bin/pmtiles-convert#L11), so it didn't describe the command correctly.