### PR TITLE
Add CORS response header

### DIFF
--- a/serverless/aws/lambda_function.py
+++ b/serverless/aws/lambda_function.py
@@ -77,7 +77,10 @@ def lambda_handler(event, context):
         else:
             raise e
 
-    headers = {"Content-Type": "application/protobuf"}
+    headers = {
+        "Content-Type": "application/protobuf",
+        "Access-Control-Allow-Origin": "*",
+    }
 
     if reader.header().metadata.get("compression") == "gzip":
         if is_api_gateway:


### PR DESCRIPTION
This is a ham-fisted way to provide CORS support. For API Gateway Lambda proxy integrations there’s not an opportunity to attach new response headers so they have to come from within Lambda.