### PR TITLE
Implemented most of an attribute-matching parser

### DIFF
--- a/serverless/aws/test_util.py
+++ b/serverless/aws/test_util.py
@@ -1,5 +1,119 @@
 import unittest
+import util
 from util import parse_tile_path, pmtiles_path
+
+
+class TestAttributes(unittest.TestCase):
+    def test_just_attributes(self):
+        self.assertEqual(
+            util.parse_attributes("foobar"),
+            [(True, "foobar")],
+            "Should not split on missing comma",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo,bar,baz"),
+            [(True, "foo"), (True, "bar"), (True, "baz")],
+            "Should split on simple comma",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo\\,bar"),
+            [(True, "foo,bar")],
+            "Should not split on escaped comma",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo\\\,bar"),
+            [(True, "foo\\,bar")],
+            "Should not split on escaped comma while allowing escape backslash",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo,bar\\,baz"),
+            [(True, "foo"), (True, "bar,baz")],
+            "Should split on complex commas",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo\\,bar,baz"),
+            [(True, "foo,bar"), (True, "baz")],
+            "Should split on complex commas",
+        )
+
+    def test_catchall_attributes(self):
+        self.assertEqual(
+            util.parse_attributes(None),
+            [(True, True)],
+            "Should match all attributes for no value provided",
+        )
+        self.assertEqual(
+            util.parse_attributes("*"),
+            [(True, True)],
+            "Should match all attributes for catchall asterisk",
+        )
+        self.assertEqual(
+            util.parse_attributes(""),
+            [(True, False)],
+            "Should match no attributes for an empty string",
+        )
+        self.assertEqual(
+            util.parse_attributes("\\"),
+            [(True, "\\")],
+            "Should match attributes named with literal backslash",
+        )
+        self.assertEqual(
+            util.parse_attributes("\\*"),
+            [(True, "*")],
+            "Should match attributes named with literal asterisk",
+        )
+        self.assertEqual(
+            util.parse_attributes("*:foo,*:bar"),
+            [(True, "foo"), (True, "bar")],
+            "Should match attributes on catchall tables",
+        )
+        self.assertEqual(
+            util.parse_attributes("\\*:foo,\\*:bar"),
+            [("*", "foo"), ("*", "bar")],
+            "Should match attributes on tables named with asterisks",
+        )
+
+    def test_named_tables(self):
+        self.assertEqual(
+            util.parse_attributes("foo:bar"),
+            [("foo", "bar")],
+            "Should match attribute on provided table",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo:*"),
+            [("foo", True)],
+            "Should match all attributes on provided table",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo\\::"),
+            [("foo:", False)],
+            "Should match no attributes on provided table",
+        )
+        self.assertEqual(
+            util.parse_attributes("\\,foo\\::\\:bar\\,"),
+            [(",foo:", ":bar,")],
+            "Should match attribute on provided table",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo:bar,baz:quux"),
+            [("foo", "bar"), ("baz", "quux")],
+            "Should match attributes on provided tables",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo,bar:baz"),
+            [(True, "foo"), ("bar", "baz")],
+            "Should match attributes on provided tables",
+        )
+        self.assertEqual(
+            util.parse_attributes("foo:bar,baz"),
+            [("foo", "bar"), (True, "baz")],
+            "Should match attributes on provided tables",
+        )
+        self.assertEqual(
+            util.parse_attributes(":foo,:bar"),
+            [(False, "foo"), (False, "bar")],
+            "Should match attributes on no tables",
+        )
 
 
 class TestLambda(unittest.TestCase):

--- a/serverless/aws/util.py
+++ b/serverless/aws/util.py
@@ -25,3 +25,37 @@ def parse_tile_path(p, str):
         m.group("name"),
         Zxy(int(m.group("z")), int(m.group("x")), int(m.group("y"))),
     )
+
+
+def parse_attribute(string):
+    """Convert string representing single attribut to (table, attribute) tuple.
+
+    Boolean True in either position matches anything, False matches nothing."""
+    if string is None:
+        return (True, True)
+    parts = [part.replace("\\:", ":") for part in re.split(r"(?<!\\):", string, 1)]
+    if parts[-1] == "*":
+        attribute = True
+    elif parts[-1] == "":
+        attribute = False
+    else:
+        attribute = parts[-1].replace("\\*", "*")
+    if len(parts) == 1:
+        table = True
+    elif parts[-2] == "*":
+        table = True
+    elif parts[-2] == "":
+        table = False
+    else:
+        table = parts[-2].replace("\\*", "*")
+    return (table, attribute)
+
+
+def parse_attributes(string):
+    """Convert string representing sequence of comma-delimited attributes to list"""
+    if string is None:
+        return [parse_attribute(string)]
+    return [
+        parse_attribute(part.replace("\\,", ","))
+        for part in re.split(r"(?<!\\),", string)
+    ]


### PR DESCRIPTION
Attribute parsing intended for selecting specific layers and attributes out of tiles, e.g.:

* `0/0/0.pbf` – include all attributes
* `0/0/0.pbf?attributes=*` – include all attributes
* `0/0/0.pbf?attributes=` – include **no** attributes
* `0/0/0.pbf?attributes=a1,a2` – Only attributes `a1` and `a2` from any layer
* `0/0/0.pbf?attributes=L1:a1,L2:b2` – Only attribute `a1` from layer `L1` and attribute `a2` from layer `L2`
* `0/0/0.pbf?attributes=L1:a1,L2:*` – Only attribute `a1` from layer `L1` and all attributes from layer `L2`
* `0/0/0.pbf?attributes=a1,L2:*` – Attribute `a1` from any layer and all attributes from layer `L2`

The only case I’m not handling reliably is backslashes in certain situations, just don’t think I’m doing the full recursive escape/parse dance correctly.