### PR TITLE
avoid allocation in rotate

### DIFF
--- a/spec/converter/tile_id.go
+++ b/spec/converter/tile_id.go
@@ -8,9 +8,7 @@ func rotate(n int64, x *int64, y *int64, rx int64, ry int64) {
 			*x = n - 1 - *x
 			*y = n - 1 - *y
 		}
-		t := *x
-		*x = *y
-		*y = t
+		*x, *y = *y, *x
 	}
 }
 


### PR DESCRIPTION
can this trick be used to avoid allocating `t`?
https://go.dev/play/p/SMPKQaq-DDD