### PR TITLE
clarify build instructions for AWS lambda function

### DIFF
--- a/serverless/aws/README.md
+++ b/serverless/aws/README.md
@@ -4,7 +4,7 @@ See installation and configuration instructions at [Protomaps Docs: Deploy on AW
 
 ## Development
 
-The code for the lambda function imports from the top level `js/` directory. You will therfore need to first run `npm install` and `npm run build` in the `js/` directory, and then run `npm run build` in the `serverless/aws` directory.
+The code for the lambda function imports from the top level `js/` directory. You will therfore need to first run `npm install` and `npm run build` in the `js/` directory, and then run `npm install` in the `serverless/aws` directory.
 
 You should then be able to build the Lambda ZIP:
 

--- a/serverless/aws/README.md
+++ b/serverless/aws/README.md
@@ -4,7 +4,9 @@ See installation and configuration instructions at [Protomaps Docs: Deploy on AW
 
 ## Development
 
-Building the Lambda ZIP yourself:
+The code for the lambda function imports from the top level `js/` directory. You will therfore need to first run `npm install` and `npm run build` in the `js/` directory, and then run `npm run build` in the `serverless/aws` directory.
+
+You should then be able to build the Lambda ZIP:
 
 ```sh
 npm run build


### PR DESCRIPTION
Doing a clean checkout then npm run build isn't enough to build the Lambda function - it will result in errors like 

```
X [ERROR] Could not resolve "fflate"

    ../../js/index.ts:1:31:
      1 │ import { decompressSync } from "fflate";
        ╵                                ~~~~~~~~

  You can mark the path "fflate" as external to exclude it from the bundle, which will remove this
  error.
```