### PR TITLE
disable "Load URL" button if url is empty

### DIFF
--- a/app/src/Start.tsx
+++ b/app/src/Start.tsx
@@ -142,7 +142,7 @@ function Start(props: {
         placeholder="https://example.com/my_archive.pmtiles"
         onChange={onRemoteUrlChangeHandler}
       ></Input>
-      <Button color="gray" onClick={onSubmit}>
+      <Button color="gray" onClick={onSubmit} disabled={!remoteUrl.trim()}>
         Load URL
       </Button>
       <Label htmlFor="localFile">Select a local file</Label>


### PR DESCRIPTION
This prevents the user from accidentally clicking the button if they try to quickly click on the file drop-zone (currently, doing this would display an error, and the user would need to press the back button in their browser to return to the start form).
