### PR TITLE
Allow for PMTiles with WebP raster tiles

### DIFF
--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -287,6 +287,7 @@ function MaplibreMap(props: { file: PMTiles }) {
         let style: any; // TODO maplibre types (not any)
         if (
           header.tileType === TileType.Png ||
+          header.tileType === TileType.Webp ||
           header.tileType == TileType.Jpeg
         ) {
           let style = await rasterStyle(props.file);


### PR DESCRIPTION
Fix for using PMtiles with WebP rasters.  Enables the site [protomaps.github.io/PMTiles](https://protomaps.github.io/PMTiles) to allow to test WebP tiles.



### Test results

1. Tested in a local build of `/app`
2. Tested with a WebP PMTiles (generated via QGIS > MBTiles > `pmtiles convert`)
3. The WebP PMTiles file is 2 MB, and we can donate to the project

---

Output from the Metadata tab:

* `tile type: 4` — Maps to `TileType.Webp`
* `"format": "webp"` — format from the QGIS tile cutter

---

```console
root directory: offset=127 len=232
metadata: offset=359 len=210
leaf directories: offset=569 len=0
tile data: offset=569 len=1964030
num addressed tiles: 50
num tile entries: 50
num tile contents: 50
clustered: true
internal compression: 2
tile compression: 1
tile type: 4
min zoom: 8
max zoom: 15
min lon, min lat, max lon, max lat: -118.31982, 36.56109, -118.26069, 36.59301
center zoom: 12
center lon, center lat: -118.2903, 36.577

{
  "attribution": "Created by QGIS algorithm: Generate XYZ tiles (Directory)",
  "description": "",
  "format": "webp",
  "maxzoom": "15",
  "minzoom": "8",
  "name": "",
  "profile": "mercator",
  "scheme": "xyz",
  "tileSize": "512",
  "tilejson": "1.0.99",
  "type": "raster",
  "version": "1.0.0",
  "volatile": "0"
}
```

---

*Example with WebP PMTiles*
<img width="61.8%" alt="image" src="https://user-images.githubusercontent.com/118112/225168258-e12ec991-89d4-4042-8da3-b4d08412b54d.png">
