### PR TITLE
Fix tile loading

### DIFF
--- a/js/examples/openlayers.html
+++ b/js/examples/openlayers.html
@@ -46,6 +46,7 @@
                       tile.setFeatures(features);
                       tile.setState(2); // LOADED
                     } else {
+                      tile.setFeatures([]);
                       tile.setState(4); // EMPTY
                     }
                   });


### PR DESCRIPTION
When testing the openlayers demo application, we discovered an issue after a certain amount of features had been loaded where no new tiles will get fetched anymore.

To see the issue in action one needs to zoom in and out a lot on different locations to fetch a lot of features.
After some time, ~1 minute, tiles will stop loading and the map gets blurry when zooming in and does not display new features.

It seems related to the following issue https://github.com/openlayers/openlayers/issues/8276
which inspired the change made here.
After that change, tiles load correctly.


