### PR TITLE
PMTiles Viewer UX enhancements

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { styled, globalStyles } from "./stitches.config";
 import { PMTiles } from "../../js/index";
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
@@ -14,9 +14,10 @@ const Header = styled("div", {
   padding: "0 $2 0 $2",
 });
 
-const Title = styled("span", {
+const Title = styled("a", {
   fontWeight: 500,
-  cursor: "pointer",
+  color: "unset",
+  textDecoration: "none",
 });
 
 const GithubA = styled("a", {
@@ -88,7 +89,8 @@ function App() {
     }
   }, [file]);
 
-  let clear = () => {
+  let clear = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     setFile(undefined);
   };
 
@@ -99,7 +101,7 @@ function App() {
   return (
     <div>
       <Header>
-        <Title onClick={clear}>PMTiles Viewer</Title>
+        <Title href="/" onClick={clear}>PMTiles Viewer</Title>
         <GithubLink>
           <GithubA href="https://github.com/protomaps/PMTiles" target="_blank">
             <GitHubLogoIcon /> {GIT_SHA}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -101,7 +101,9 @@ function App() {
   return (
     <div>
       <Header>
-        <Title href="/" onClick={clear}>PMTiles Viewer</Title>
+        <Title href="/" onClick={clear}>
+          PMTiles Viewer
+        </Title>
         <GithubLink>
           <GithubA href="https://github.com/protomaps/PMTiles" target="_blank">
             <GitHubLogoIcon /> {GIT_SHA}

--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { renderToString } from "react-dom/server";
 import { PMTiles, TileType } from "../../js/index";
 import { Protocol } from "../../js/adapters";
@@ -50,30 +50,104 @@ const Options = styled("div", {
   zIndex: 9999,
 });
 
+const CheckboxLabel = styled("label", {
+  display: "flex",
+  gap: 6,
+  cursor: "pointer",
+});
+
+const LayersVisibilityList = styled("ul", {
+  listStyleType: "none",
+});
+
 const FeaturesProperties = (props: { features: MapGeoJSONFeature[] }) => {
-  const fs = props.features.map((f, i) => {
-    let tmp: [string, string][] = [];
-    for (var key in f.properties) {
-      tmp.push([key, f.properties[key]]);
+  return (
+    <PopupContainer>
+      {props.features.map((f, i) => (
+        <FeatureRow key={i}>
+          <span>
+            <strong>{(f.layer as any)["source-layer"]}</strong>
+            <span style={{fontSize: "0.8em"}}> ({f.geometry.type})</span>
+          </span>
+          <table>
+            {Object.entries(f.properties).map(([key, value], i) => (
+              <tr key={i}>
+                <td>{key}</td>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </table>
+        </FeatureRow>
+      ))}
+    </PopupContainer>
+  );
+};
+
+interface LayerVisibility {
+  id: string;
+  visible: boolean;
+}
+
+const LayersVisibilityController = (props: { layers: LayerVisibility[], onChange: (layers: LayerVisibility[]) => void }) => {
+  const {layers, onChange} = props;
+  const allLayersCheckboxRef = useRef<HTMLInputElement>(null);
+  const visibleLayersCount = layers.filter(l => l.visible).length;
+  const indeterminate = visibleLayersCount > 0 && visibleLayersCount !== layers.length;
+
+  useEffect(() => {
+    if (allLayersCheckboxRef.current) {
+      allLayersCheckboxRef.current.indeterminate = indeterminate;
     }
+  }, [indeterminate]);
 
-    const rows = tmp.map((d, i) => (
-      <tr key={i}>
-        <td>{d[0]}</td>
-        <td>{d[1]}</td>
-      </tr>
-    ));
-
+  if (!props.layers.length) {
     return (
-      <FeatureRow key={i}>
-        <div>
-          <strong>{(f.layer as any)["source-layer"]}</strong>
-        </div>
-        <table>{rows}</table>
-      </FeatureRow>
+      <>
+        <h4>Layers</h4>
+        <span>No vector layers found</span>
+      </>
     );
-  });
-  return <PopupContainer>{fs}</PopupContainer>;
+  }
+
+  const toggleAllLayers = () => {
+    const someLayersAreHidden = visibleLayersCount !== layers.length;
+    onChange(layers.map(l => ({...l, visible: someLayersAreHidden})));
+  };
+
+  const toggleLayer = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const layerId = event.target.getAttribute("data-layer-id");
+    onChange(layers.map(l => (l.id === layerId ? {...l, visible: !l.visible} : l)));
+  };
+
+  return (
+    <>
+      <h4>Layers</h4>
+      <CheckboxLabel>
+        <input
+          ref={allLayersCheckboxRef}
+          type="checkbox"
+          checked={visibleLayersCount === layers.length}
+          onChange={toggleAllLayers}
+        />
+        <em>All layers</em>
+      </CheckboxLabel>
+      <LayersVisibilityList>
+        {props.layers.map(({id, visible}) => (
+          <li key={id}>
+            <CheckboxLabel style={{paddingLeft: 8}}>
+              <input
+                type="checkbox"
+                checked={visible}
+                onChange={toggleLayer}
+                data-layer-id={id}
+              />
+              {id}
+            </CheckboxLabel>
+          </li>
+        ))}
+      </LayersVisibilityList>
+    </>
+  );
 };
 
 const rasterStyle = async (file: PMTiles): Promise<any> => {
@@ -188,26 +262,29 @@ const vectorStyle = async (file: PMTiles): Promise<any> => {
   const bounds = [header.minLon, header.minLat, header.maxLon, header.maxLat];
 
   return {
-    version: 8,
-    sources: {
-      source: {
-        type: "vector",
-        tiles: ["pmtiles://" + file.source.getKey() + "/{z}/{x}/{y}"],
-        minzoom: header.minZoom,
-        maxzoom: header.maxZoom,
-        bounds: bounds,
+    style: {
+      version: 8,
+      sources: {
+        source: {
+          type: "vector",
+          tiles: ["pmtiles://" + file.source.getKey() + "/{z}/{x}/{y}"],
+          minzoom: header.minZoom,
+          maxzoom: header.maxZoom,
+          bounds: bounds,
+        },
+        basemap: {
+          type: "vector",
+          tiles: [
+            "https://api.protomaps.com/tiles/v2/{z}/{x}/{y}.pbf?key=1003762824b9687f",
+          ],
+          maxzoom: 14,
+          bounds: bounds,
+        },
       },
-      basemap: {
-        type: "vector",
-        tiles: [
-          "https://api.protomaps.com/tiles/v2/{z}/{x}/{y}.pbf?key=1003762824b9687f",
-        ],
-        maxzoom: 14,
-        bounds: bounds,
-      },
+      glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
+      layers: layers,
     },
-    glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
-    layers: layers,
+    layersVisibility: vector_layers.map((l: any) => ({id: l.id, visible: true})),
   };
 };
 
@@ -216,6 +293,7 @@ function MaplibreMap(props: { file: PMTiles }) {
   let [hamburgerOpen, setHamburgerOpen] = useState<boolean>(true);
   let [showAttributes, setShowAttributes] = useState<boolean>(false);
   let [showTileBoundaries, setShowTileBoundaries] = useState<boolean>(false);
+  let [layersVisibility, setLayersVisibility] = useState<LayerVisibility[]>([]);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const hoveredFeaturesRef = useRef<Set<MapGeoJSONFeature>>(new Set());
 
@@ -238,6 +316,15 @@ function MaplibreMap(props: { file: PMTiles }) {
     setShowTileBoundaries(!showTileBoundaries);
     mapRef.current!.showTileBoundaries = !showTileBoundaries;
   };
+
+  const handleLayersVisibilityChange = (layersVisibility: LayerVisibility[]) => {
+    setLayersVisibility(layersVisibility);
+    for (const {id, visible} of layersVisibility) {
+      mapRef.current!.setLayoutProperty(`${id}_fill`, "visibility", visible ? "visible" : "none");
+      mapRef.current!.setLayoutProperty(`${id}_stroke`, "visibility", visible ? "visible" : "none");
+      mapRef.current!.setLayoutProperty(`${id}_point`, "visibility", visible ? "visible" : "none");
+    }
+  }
 
   useEffect(() => {
     let protocol = new Protocol();
@@ -327,8 +414,9 @@ function MaplibreMap(props: { file: PMTiles }) {
           let style = await rasterStyle(props.file);
           map.setStyle(style);
         } else {
-          let style = await vectorStyle(props.file);
+          let {style, layersVisibility} = await vectorStyle(props.file);
           map.setStyle(style);
+          setLayersVisibility(layersVisibility);
         }
       }
     };
@@ -344,21 +432,27 @@ function MaplibreMap(props: { file: PMTiles }) {
         <Options>
           <h4>Filter</h4>
           <h4>Popup</h4>
-          <input
-            type="checkbox"
-            id="showAttributes"
-            checked={showAttributes}
-            onChange={toggleShowAttributes}
-          />
-          <label htmlFor="showAttributes">show attributes</label>
+          <CheckboxLabel>
+            <input
+              type="checkbox"
+              checked={showAttributes}
+              onChange={toggleShowAttributes}
+            />
+            show attributes
+          </CheckboxLabel>
           <h4>Tiles</h4>
-          <input
-            type="checkbox"
-            id="showTileBoundaries"
-            checked={showTileBoundaries}
-            onChange={toggleShowTileBoundaries}
+          <CheckboxLabel>
+            <input
+              type="checkbox"
+              checked={showTileBoundaries}
+              onChange={toggleShowTileBoundaries}
+            />
+            show tile boundaries
+          </CheckboxLabel>
+          <LayersVisibilityController
+            layers={layersVisibility}
+            onChange={handleLayersVisibilityChange}
           />
-          <label htmlFor="showTileBoundaries">show tile boundaries</label>
         </Options>
       ) : null}
     </MapContainer>

--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -67,7 +67,7 @@ const FeaturesProperties = (props: { features: MapGeoJSONFeature[] }) => {
         <FeatureRow key={i}>
           <span>
             <strong>{(f.layer as any)["source-layer"]}</strong>
-            <span style={{fontSize: "0.8em"}}> ({f.geometry.type})</span>
+            <span style={{ fontSize: "0.8em" }}> ({f.geometry.type})</span>
           </span>
           <table>
             {Object.entries(f.properties).map(([key, value], i) => (
@@ -88,11 +88,15 @@ interface LayerVisibility {
   visible: boolean;
 }
 
-const LayersVisibilityController = (props: { layers: LayerVisibility[], onChange: (layers: LayerVisibility[]) => void }) => {
-  const {layers, onChange} = props;
+const LayersVisibilityController = (props: {
+  layers: LayerVisibility[];
+  onChange: (layers: LayerVisibility[]) => void;
+}) => {
+  const { layers, onChange } = props;
   const allLayersCheckboxRef = useRef<HTMLInputElement>(null);
-  const visibleLayersCount = layers.filter(l => l.visible).length;
-  const indeterminate = visibleLayersCount > 0 && visibleLayersCount !== layers.length;
+  const visibleLayersCount = layers.filter((l) => l.visible).length;
+  const indeterminate =
+    visibleLayersCount > 0 && visibleLayersCount !== layers.length;
 
   useEffect(() => {
     if (allLayersCheckboxRef.current) {
@@ -110,13 +114,17 @@ const LayersVisibilityController = (props: { layers: LayerVisibility[], onChange
   }
 
   const toggleAllLayers = () => {
-    const someLayersAreHidden = visibleLayersCount !== layers.length;
-    onChange(layers.map(l => ({...l, visible: someLayersAreHidden})));
+    const visible = visibleLayersCount !== layers.length;
+    const newLayersVisibility = layers.map((l) => ({ ...l, visible }));
+    onChange(newLayersVisibility);
   };
 
   const toggleLayer = (event: React.ChangeEvent<HTMLInputElement>) => {
     const layerId = event.target.getAttribute("data-layer-id");
-    onChange(layers.map(l => (l.id === layerId ? {...l, visible: !l.visible} : l)));
+    const newLayersVisibility = layers.map((l) =>
+      l.id === layerId ? { ...l, visible: !l.visible } : l
+    );
+    onChange(newLayersVisibility);
   };
 
   return (
@@ -132,9 +140,9 @@ const LayersVisibilityController = (props: { layers: LayerVisibility[], onChange
         <em>All layers</em>
       </CheckboxLabel>
       <LayersVisibilityList>
-        {props.layers.map(({id, visible}) => (
+        {props.layers.map(({ id, visible }) => (
           <li key={id}>
-            <CheckboxLabel style={{paddingLeft: 8}}>
+            <CheckboxLabel style={{ paddingLeft: 8 }}>
               <input
                 type="checkbox"
                 checked={visible}
@@ -284,7 +292,10 @@ const vectorStyle = async (file: PMTiles): Promise<any> => {
       glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
       layers: layers,
     },
-    layersVisibility: vector_layers.map((l: any) => ({id: l.id, visible: true})),
+    layersVisibility: vector_layers.map((l: any) => ({
+      id: l.id,
+      visible: true,
+    })),
   };
 };
 
@@ -309,7 +320,9 @@ function MaplibreMap(props: { file: PMTiles }) {
 
   const toggleShowAttributes = () => {
     setShowAttributes(!showAttributes);
-    mapRef.current!.getCanvas().style.cursor = !showAttributes ? "crosshair" : "";
+    mapRef.current!.getCanvas().style.cursor = !showAttributes
+      ? "crosshair"
+      : "";
   };
 
   const toggleShowTileBoundaries = () => {
@@ -317,14 +330,18 @@ function MaplibreMap(props: { file: PMTiles }) {
     mapRef.current!.showTileBoundaries = !showTileBoundaries;
   };
 
-  const handleLayersVisibilityChange = (layersVisibility: LayerVisibility[]) => {
+  const handleLayersVisibilityChange = (
+    layersVisibility: LayerVisibility[]
+  ) => {
     setLayersVisibility(layersVisibility);
-    for (const {id, visible} of layersVisibility) {
-      mapRef.current!.setLayoutProperty(`${id}_fill`, "visibility", visible ? "visible" : "none");
-      mapRef.current!.setLayoutProperty(`${id}_stroke`, "visibility", visible ? "visible" : "none");
-      mapRef.current!.setLayoutProperty(`${id}_point`, "visibility", visible ? "visible" : "none");
+    const map = mapRef.current!;
+    for (const { id, visible } of layersVisibility) {
+      const visibility = visible ? "visible" : "none";
+      map.setLayoutProperty(`${id}_fill`, "visibility", visibility);
+      map.setLayoutProperty(`${id}_stroke`, "visibility", visibility);
+      map.setLayoutProperty(`${id}_point`, "visibility", visibility);
     }
-  }
+  };
 
   useEffect(() => {
     let protocol = new Protocol();
@@ -355,7 +372,7 @@ function MaplibreMap(props: { file: PMTiles }) {
     map.on("mousemove", (e) => {
       const hoveredFeatures = hoveredFeaturesRef.current;
       for (const feature of hoveredFeatures) {
-        map.setFeatureState(feature, {hover: false});
+        map.setFeatureState(feature, { hover: false });
         hoveredFeatures.delete(feature);
       }
 
@@ -364,15 +381,18 @@ function MaplibreMap(props: { file: PMTiles }) {
         return;
       }
 
-      const {x, y} = e.point;
+      const { x, y } = e.point;
       const r = 2; // radius around the point
-      var features = map.queryRenderedFeatures([[x-r, y-r], [x+r,y+r]]);
+      var features = map.queryRenderedFeatures([
+        [x - r, y - r],
+        [x + r, y + r],
+      ]);
 
       // ignore the basemap
       features = features.filter((feature) => feature.source === "source");
 
       for (const feature of features) {
-        map.setFeatureState(feature, {hover: true});
+        map.setFeatureState(feature, { hover: true });
         hoveredFeatures.add(feature);
       }
 
@@ -414,7 +434,7 @@ function MaplibreMap(props: { file: PMTiles }) {
           let style = await rasterStyle(props.file);
           map.setStyle(style);
         } else {
-          let {style, layersVisibility} = await vectorStyle(props.file);
+          let { style, layersVisibility } = await vectorStyle(props.file);
           map.setStyle(style);
           setLayersVisibility(layersVisibility);
         }


### PR DESCRIPTION
Changes in PMTiles Viewer app:
1) hover effect while in "show attributes" mode; allow for bigger margin - 4x4px instead of 1x1px
![localhost_3000__url=https%3A%2F%2Fprotomaps github io%2FPMTiles%2Fprotomaps%28vector%29ODbL_firenze pmtiles (1)](https://user-images.githubusercontent.com/16785518/227775856-b0658051-c940-470b-89d3-4f0ccf238b6c.png)

2) Option to toggle vector layer visibility
![localhost_3000__url=https%3A%2F%2Fprotomaps github io%2FPMTiles%2Fprotomaps%28vector%29ODbL_firenze pmtiles](https://user-images.githubusercontent.com/16785518/227775741-78ab9f76-9a18-4ac3-9cfd-7e1d4409a329.png)
