### PR TITLE
PMTiles Viewer invalid link href in GitHub Pages - Bugfix

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
   return (
     <div>
       <Header>
-        <Title href="/" onClick={clear}>
+        <Title href="/PMTiles/" onClick={clear}>
           PMTiles Viewer
         </Title>
         <GithubLink>


### PR DESCRIPTION
Clicking the link in the title (open in new tab/window) results in opening https://protomaps.github.io/ instead of https://protomaps.github.io/PMTiles/.
Which is odd considering that the base url is set to `/PMTiles/` in [the build script](https://github.com/protomaps/PMTiles/blob/081be12fdbbc33eda7c41f203063b3c596eed719/.github/workflows/actions.yml#L23).

Setting `href={import.meta.env.BASE_URL}`, from my local attempts, doesn't look like it can fix the error.
Thus this straightforward fix below.