### PR TITLE
Remove max-width for tooltips

### DIFF
--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -381,7 +381,7 @@ function MaplibreMap(props: { file: PMTiles }) {
     const popup = new maplibregl.Popup({
       closeButton: false,
       closeOnClick: false,
-      maxWidth: 'none',
+      maxWidth: "none",
     });
 
     mapRef.current = map;

--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -381,6 +381,7 @@ function MaplibreMap(props: { file: PMTiles }) {
     const popup = new maplibregl.Popup({
       closeButton: false,
       closeOnClick: false,
+      maxWidth: 'none',
     });
 
     mapRef.current = map;


### PR DESCRIPTION
I have some map tiles with long property names - currently the tooltip is too narrow, so text extends beyond the tooltip's white background.

The Maplibre docs say that `options.maxWidth` is "A string that sets the CSS property of the popup's maximum width, eg '300px' . To ensure the popup resizes to fit its content, set this property to 'none'"

https://maplibre.org/maplibre-gl-js-docs/api/markers/#popup