### PR TITLE
use compression-stream-polyfill for faster, native gzip decompression 

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pmtiles",
-  "version": "2.7.2",
+  "version": "2.8.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pmtiles",
-      "version": "2.7.2",
+      "version": "2.8.0-beta.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "compression-streams-polyfill": "^0.1.3",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "fflate": "^0.7.3"
+        "compression-streams-polyfill": "^0.1.3",
+        "fflate": "^0.8.0"
       },
       "devDependencies": {
         "@types/node": "^18.11.9",
@@ -62,6 +63,19 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/compression-streams-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/compression-streams-polyfill/-/compression-streams-polyfill-0.1.3.tgz",
+      "integrity": "sha512-FOvusJGoWTKRb9JNMtCc42C81SdyJhJws/lbExADOkH1R8KpdzY4yFO6953lW5Vw498pnGXoyosr807KTr8BAA==",
+      "dependencies": {
+        "fflate": "^0.7.4"
+      }
+    },
+    "node_modules/compression-streams-polyfill/node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "node_modules/esbuild": {
       "version": "0.15.15",
@@ -437,9 +451,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "node_modules/prettier": {
       "version": "2.8.4",
@@ -521,6 +535,21 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "compression-streams-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/compression-streams-polyfill/-/compression-streams-polyfill-0.1.3.tgz",
+      "integrity": "sha512-FOvusJGoWTKRb9JNMtCc42C81SdyJhJws/lbExADOkH1R8KpdzY4yFO6953lW5Vw498pnGXoyosr807KTr8BAA==",
+      "requires": {
+        "fflate": "^0.7.4"
+      },
+      "dependencies": {
+        "fflate": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+          "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+        }
+      }
     },
     "esbuild": {
       "version": "0.15.15",
@@ -703,9 +732,9 @@
       "optional": true
     },
     "fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "prettier": {
       "version": "2.8.4",

--- a/js/package.json
+++ b/js/package.json
@@ -32,6 +32,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "fflate": "^0.7.3"
+    "compression-streams-polyfill": "^0.1.3",
+    "fflate": "^0.8.0"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmtiles",
-  "version": "2.7.2",
+  "version": "2.8.0-beta.0",
   "description": "PMTiles archive decoder for browsers",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
issues: #97, #167

This affects the browser environment and other JS environments; the NodeJS implementation for Lambda still uses the `zlib` module ([link to source](https://github.com/protomaps/PMTiles/blob/main/serverless/aws/src/index.ts#L30)) but I think can use this as well?

It means all environments need to support the standard `Response` API but I think that's true of everything we're targeting (browsers, Node 18+, CF Workers, Deno later)