### PR TITLE
serverless: improve error message if request doesn't match archive type

### DIFF
--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -192,7 +192,7 @@ export const handlerRaw = async (
         }
         return apiResp(
           400,
-          "Bad request: archive has type ." + pair[1],
+          `Bad request: requested .${ext} but archive has type .${pair[1]}`,
           false,
           headers
         );

--- a/serverless/cloudflare/src/index.ts
+++ b/serverless/cloudflare/src/index.ts
@@ -200,7 +200,7 @@ export default {
               continue;
             }
             return cacheableResponse(
-              "Bad request: archive has type ." + pair[1],
+              `Bad request: requested .${ext} but archive has type .${pair[1]}`,
               cacheable_headers,
               400
             );


### PR DESCRIPTION
See #190 