### PR TITLE
add ETag and cache-control headers for 200 responses

### DIFF
--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -208,7 +208,7 @@ export const handlerRaw = async (
       }
 
       headers["Cache-Control"] = `public, max-age=${process.env.CACHE_MAX_AGE || 86400}`;
-      headers["eTag"] = `"${createHash("sha256").update(Buffer.from(data)).digest("hex")}"`
+      headers["ETag"] = `"${createHash("sha256").update(Buffer.from(data)).digest("hex")}"`
 
       if (is_api_gateway) {
         // this is wasted work, but we need to force API Gateway to interpret the Lambda response as binary

--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { pmtiles_path, tile_path, tileJSON } from "../../shared/index";
 
 import zlib from "zlib";
+import { createHash } from "crypto"
 
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
@@ -206,6 +207,9 @@ export const handlerRaw = async (
         data = tilePostprocess(data, header.tileType);
       }
 
+      headers["Cache-Control"] = `public, max-age=${process.env.CACHE_MAX_AGE || 86400}`;
+      headers["eTag"] = `"${createHash("sha256").update(Buffer.from(data)).digest("hex")}"`
+
       if (is_api_gateway) {
         // this is wasted work, but we need to force API Gateway to interpret the Lambda response as binary
         // without depending on clients sending matching Accept: headers in the request.
@@ -235,7 +239,6 @@ export const handlerRaw = async (
     }
     throw e;
   }
-  return apiResp(404, "Invalid URL", false, headers);
 };
 
 export const handler = async (


### PR DESCRIPTION
Using a sha256sum of the data seemed liked the easiest option for the ETag it also means that if the pmtiles file changes but the data does not the tile can be cached between updates.

