### PR TITLE
Spec 3.3

### DIFF
--- a/spec/v3/CHANGELOG.md
+++ b/spec/v3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 3.3
+- Narrow `clustered` meaning: first tile entry must be offset 0.
+- Add language discouraging the creation of nested leaf directories.
+
 ## Version 3.2
 - Detailed rewrite of spec by @DerZade to clarify ambiguity.
 

--- a/spec/v3/CHANGELOG.md
+++ b/spec/v3/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 3.3
 - Narrow `clustered` meaning: first tile entry must be offset 0.
 - Add language discouraging the creation of nested leaf directories.
+- add recommended MIME Type.
 
 ## Version 3.2
 - Detailed rewrite of spec by @DerZade to clarify ambiguity.

--- a/spec/v3/spec.md
+++ b/spec/v3/spec.md
@@ -10,6 +10,8 @@ Please refer to the [change log](./CHANGELOG.md) for a documentation of changes 
 
 PMTiles is a single-file archive format for tiled data.
 
+The recommended MIME Type for PMTiles is `application/vnd.pmtiles`.
+
 ## 2 Overview
 
 A PMTiles archive consists of five main sections:

--- a/spec/v3/spec.md
+++ b/spec/v3/spec.md
@@ -148,7 +148,10 @@ This field is encoded as a little-endian 64-bit unsigned integer.
 #### Clustered (C)
 
 Clustered is a 1-byte field specifying if the data of the individual tiles in the data section is ordered by their TileID (clustered) or not (not clustered).
-Therefore, Clustered means that offsets are either contiguous with the previous offset+length, or refer to a lesser offset when writing with deduplication.
+Therefore, Clustered means that:
+
+* offsets are either contiguous with the previous offset+length, or refer to a lesser offset when writing with deduplication.
+* the first tile entry in the directory has offset 0.
 
 The field can have one of the following values:
 
@@ -256,6 +259,8 @@ A directory is simply a list of entries. Each entry describes either where a spe
 
 The number of entries in the root directory and in the leaf directories is left to the implementation and can vary depending on what the writer has optimized for (cost, bandwidth, latency, etc.).
 However, the size of the header plus the compressed size of the root directory MUST NOT exceed 16384 bytes to allow latency-optimized clients to retrieve the root directory in its entirety. Therefore, the **maximum compressed size of the root directory is 16257 bytes** (16384 bytes - 127 bytes). A sophisticated writer might need several attempts to optimize this.
+
+It is discouraged to create an archive with more than one level of leaf directories. If you are implementing a writer and discover this need, please open an issue.
 
 ### 4.1 Directory Entries
 


### PR DESCRIPTION
Making an executive decision here and adding some constraints to the existing spec based on discoveries in `pmtiles extract`:

* `clustered` is only an absolute ordering if the first tile is at offset 0. All the existing implementations I know of do this already.
* Multiple levels of leaf directories have always been implicitly supported, because there wasn't any extra logic needed. However, multiple leaf directories breaks the absolute ordering of the data in the leaf section (breadth-first or depth-first?), and the situations needed - very large archives with billions+ of unique tiles - I have not encountered in a year of V3 being out.

cc @DerZade 