### PR TITLE
[ol-pmtiles] mvtOptions property to pass options to MVT Format

### DIFF
--- a/openlayers/src/index.js
+++ b/openlayers/src/index.js
@@ -78,13 +78,13 @@ export class PMTilesVectorSource extends VectorTile {
     });
   };
 
-  constructor(options) {
+  constructor({ mvtOptions, ...options }) {
     super({
       ...options,
       ...{
         state: "loading",
         url: "pmtiles://" + options.url + "/{z}/{x}/{y}",
-        format: new MVT(),
+        format: new MVT(mvtOptions),
       },
     });
 

--- a/openlayers/src/script_includes.js
+++ b/openlayers/src/script_includes.js
@@ -84,13 +84,13 @@ export class PMTilesVectorSource extends ol.source.VectorTile {
     });
   };
 
-  constructor(options) {
+  constructor({ mvtOptions, ...options }) {
     super({
       ...options,
       ...{
         state: "loading",
         url: "pmtiles://" + options.url + "/{z}/{x}/{y}",
-        format: new ol.format.MVT(),
+        format: new ol.format.MVT(mvtOptions),
       },
     });
 


### PR DESCRIPTION
I propose to add a new property called `mvtOptions` to the options of `PMTilesVectorSource` in order to pass options to `MVT` format.