### PR TITLE
Uses wrangler deploy instead of deprecated publish

### DIFF
--- a/serverless/cloudflare/package.json
+++ b/serverless/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmtiles-cloudflare",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",
     "esbuild-runner": "^2.2.2",
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "start": "wrangler dev",
-    "deploy": "wrangler publish",
+    "deploy": "wrangler deploy",
     "test": "node -r esbuild-runner/register ../shared/index.test.ts",
     "tsc": "tsc --watch",
     "build": "wrangler publish --outdir dist --dry-run"


### PR DESCRIPTION
Tiniest of tiny changes. Just got sick of the deprecation warning. Not sure if you want to bump the nonexistent version.

Also, hi @bdon! 👋