### PR TITLE
fix 3.0.0 packaging [#347]

### DIFF
--- a/js/examples/leaflet.html
+++ b/js/examples/leaflet.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
         <script src="https://unpkg.com/leaflet@1.9.0/dist/leaflet.js"></script>
-        <script src="https://unpkg.com/pmtiles@3.0.0/dist/index.js"></script>
+        <script src="https://unpkg.com/pmtiles@3.0.1/dist/pmtiles.js"></script>
         <style>
             body, #map {
                 height:100vh;

--- a/js/examples/maplibre.html
+++ b/js/examples/maplibre.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/pmtiles@3.0.0/dist/index.js"></script>
+        <script src="https://unpkg.com/pmtiles@3.0.1/dist/pmtiles.js"></script>
         <style>
             body {
                 margin: 0;

--- a/js/examples/maplibre_raster_dem.html
+++ b/js/examples/maplibre_raster_dem.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/pmtiles@3.0.0/dist/index.js"></script>
+        <script src="https://unpkg.com/pmtiles@3.0.1/dist/pmtiles.js"></script>
         <style>
             body {
                 margin: 0;

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pmtiles",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pmtiles",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/leaflet": "^1.9.8",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pmtiles",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "PMTiles archive decoder for browsers",
   "type": "module",
   "exports": "./dist/index.mjs",
@@ -11,8 +11,8 @@
     "index.ts"
   ],
   "scripts": {
-    "build-iife": "esbuild index.ts --outfile=dist/index.js --target=es6 --global-name=pmtiles --bundle --format=iife",
-    "build-esm": "esbuild index.ts --outfile=dist/index.mjs --target=es6 --global-name=pmtiles --bundle --format=esm",
+    "build-iife": "esbuild index.ts --outfile=dist/pmtiles.js --target=es6 --global-name=pmtiles --bundle --format=iife",
+    "build-esm": "esbuild index.ts --outfile=dist/index.js --target=es6 --bundle --format=esm",
     "build-tsc": "tsc --declaration --emitDeclarationOnly --outdir dist",
     "build": "npm run build-iife && npm run build-esm && npm run build-tsc",
     "test": "tsx test/index.test.ts",


### PR DESCRIPTION
* We can't have a .mjs alongside a .js, so rename the IIFE to pmtiles.js and the ES6 module to index.js.