### PR TITLE
Allow Customization of OpenLayers Format Parameters

### DIFF
--- a/openlayers/src/index.js
+++ b/openlayers/src/index.js
@@ -78,11 +78,14 @@ export class PMTilesVectorSource extends VectorTile {
   };
 
   constructor(options) {
-    options.state = "loading"
-    options.url = "pmtiles://" + options.url + "/{z}/{x}/{y}"
-    options.format = options.format || new MVT();
-
-    super(options);
+    super({
+      ...options,
+      ...{
+        state: "loading",
+        url: "pmtiles://" + options.url + "/{z}/{x}/{y}",
+        format: options.format || new MVT(),
+      },
+    });
 
     const fetchSource = new pmtiles.FetchSource(
       options.url,

--- a/openlayers/src/index.js
+++ b/openlayers/src/index.js
@@ -80,7 +80,7 @@ export class PMTilesVectorSource extends VectorTile {
   constructor(options) {
     options.state = "loading"
     options.url = "pmtiles://" + options.url + "/{z}/{x}/{y}"
-    options.format = options.format ? options.format : new MVT();
+    options.format = options.format || new MVT();
 
     super(options);
 

--- a/openlayers/src/index.js
+++ b/openlayers/src/index.js
@@ -78,14 +78,11 @@ export class PMTilesVectorSource extends VectorTile {
   };
 
   constructor(options) {
-    super({
-      ...options,
-      ...{
-        state: "loading",
-        url: "pmtiles://" + options.url + "/{z}/{x}/{y}",
-        format: new MVT(),
-      },
-    });
+    options.state = "loading"
+    options.url = "pmtiles://" + options.url + "/{z}/{x}/{y}"
+    options.format = options.format ? options.format : new MVT();
+
+    super(options);
 
     const fetchSource = new pmtiles.FetchSource(
       options.url,


### PR DESCRIPTION
As described in #407, `format` option is set as `new MVT()` for OpenLayers.

However in some cases you need to rewrite `format` and pass MVT options. 

There is two solutions:
- Pass MVT options
- Pass custom formater

In this case it's easier to go with 2nd option (passing custom formatter).

From now on you can do something like this:
```js
new PMTilesVectorSource({
  ..., 
  format: new MVT({
    featureClass: ol.Feature,
    idProperty: 'customId',
  }),
})
```