### PR TITLE
Add CACHE_CONTROL env, deprecate CACHE_MAX_AGE 

### DIFF
--- a/serverless/aws/.gitignore
+++ b/serverless/aws/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -58,11 +58,11 @@ export async function handler(
 // Assumes event is a API Gateway V2 or Lambda Function URL formatted dict
 // and returns API Gateway V2 / Lambda Function dict responses
 // Does not work with CloudFront events/Lambda@Edge; see README
-export const handlerRaw = async (
+export async function handlerRaw(
   event: APIGatewayProxyEventV2,
   _context: Context,
   tilePostprocess?: (a: ArrayBuffer, t: TileType) => ArrayBuffer
-): Promise<APIGatewayProxyResult> => {
+): Promise<APIGatewayProxyResult> {
   let path: string;
   let isApiGateway = false;
 
@@ -212,7 +212,7 @@ export const handlerRaw = async (
 
     throw error;
   }
-};
+}
 
 async function nativeDecompress(
   buffer: ArrayBuffer,

--- a/serverless/cloudflare/src/index.ts
+++ b/serverless/cloudflare/src/index.ts
@@ -15,7 +15,7 @@ interface Env {
   // biome-ignore lint: config name
   BUCKET: R2Bucket;
   // biome-ignore lint: config name
-  CACHE_MAX_AGE?: number;
+  CACHE_CONTROL?: string;
   // biome-ignore lint: config name
   PMTILES_PATH?: string;
   // biome-ignore lint: config name
@@ -24,68 +24,7 @@ interface Env {
 
 class KeyNotFoundError extends Error {}
 
-async function nativeDecompress(
-  buf: ArrayBuffer,
-  compression: Compression
-): Promise<ArrayBuffer> {
-  if (compression === Compression.None || compression === Compression.Unknown) {
-    return buf;
-  }
-  if (compression === Compression.Gzip) {
-    const stream = new Response(buf).body;
-    const result = stream?.pipeThrough(new DecompressionStream("gzip"));
-    return new Response(result).arrayBuffer();
-  }
-  throw Error("Compression method not supported");
-}
-
 const CACHE = new ResolvedValueCache(25, undefined, nativeDecompress);
-
-class R2Source implements Source {
-  env: Env;
-  archiveName: string;
-
-  constructor(env: Env, archiveName: string) {
-    this.env = env;
-    this.archiveName = archiveName;
-  }
-
-  getKey() {
-    return this.archiveName;
-  }
-
-  async getBytes(
-    offset: number,
-    length: number,
-    signal?: AbortSignal,
-    etag?: string
-  ): Promise<RangeResponse> {
-    const resp = await this.env.BUCKET.get(
-      pmtiles_path(this.archiveName, this.env.PMTILES_PATH),
-      {
-        range: { offset: offset, length: length },
-        onlyIf: { etagMatches: etag },
-      }
-    );
-    if (!resp) {
-      throw new KeyNotFoundError("Archive not found");
-    }
-
-    const o = resp as R2ObjectBody;
-
-    if (!o.body) {
-      throw new EtagMismatch();
-    }
-
-    const a = await o.arrayBuffer();
-    return {
-      data: a,
-      etag: o.etag,
-      cacheControl: o.httpMetadata?.cacheControl,
-      expires: o.httpMetadata?.cacheExpiry?.toISOString(),
-    };
-  }
-}
 
 export default {
   async fetch(
@@ -93,8 +32,9 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
-    if (request.method.toUpperCase() === "POST")
+    if (request.method.toUpperCase() === "POST") {
       return new Response(undefined, { status: 405 });
+    }
 
     const url = new URL(request.url);
     const { ok, name, tile, ext } = tile_path(url.pathname);
@@ -105,24 +45,24 @@ export default {
       return new Response("Invalid URL", { status: 404 });
     }
 
-    let allowedOrigin = "";
-    if (typeof env.ALLOWED_ORIGINS !== "undefined") {
-      for (const o of env.ALLOWED_ORIGINS.split(",")) {
-        if (o === request.headers.get("Origin") || o === "*") {
-          allowedOrigin = o;
-        }
-      }
-    }
+    const originHeader = request.headers.get("Origin");
+    const allowedOrigins = env.ALLOWED_ORIGINS || "";
+
+    const allowedOrigin = allowedOrigins
+      .split(",")
+      .find((origin) => origin === originHeader || origin === "*");
 
     const cached = await cache.match(request.url);
     if (cached) {
-      const respHeaders = new Headers(cached.headers);
-      if (allowedOrigin)
-        respHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
-      respHeaders.set("Vary", "Origin");
+      const responseHeaders = new Headers(cached.headers);
+      responseHeaders.set("Vary", "Origin");
+
+      if (allowedOrigin) {
+        responseHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
+      }
 
       return new Response(cached.body, {
-        headers: respHeaders,
+        headers: responseHeaders,
         status: cached.status,
       });
     }
@@ -134,8 +74,9 @@ export default {
     ) => {
       cacheableHeaders.set(
         "Cache-Control",
-        `max-age=${env.CACHE_MAX_AGE || 86400}`
+        env.CACHE_CONTROL || "public, max-age=86400"
       );
+
       const cacheable = new Response(body, {
         headers: cacheableHeaders,
         status: status,
@@ -143,30 +84,38 @@ export default {
 
       ctx.waitUntil(cache.put(request.url, cacheable));
 
-      const respHeaders = new Headers(cacheableHeaders);
-      if (allowedOrigin)
-        respHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
-      respHeaders.set("Vary", "Origin");
-      return new Response(body, { headers: respHeaders, status: status });
+      const responseHeaders = new Headers(cacheableHeaders);
+      responseHeaders.set("Vary", "Origin");
+
+      if (allowedOrigin) {
+        responseHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
+      }
+
+      return new Response(body, { headers: responseHeaders, status: status });
     };
 
     const cacheableHeaders = new Headers();
     const source = new R2Source(env, name);
-    const p = new PMTiles(source, CACHE, nativeDecompress);
+    const pmtiles = new PMTiles(source, CACHE, nativeDecompress);
+
     try {
-      const pHeader = await p.getHeader();
+      const pHeader = await pmtiles.getHeader();
 
       if (!tile) {
         cacheableHeaders.set("Content-Type", "application/json");
 
-        const t = tileJSON(
+        const tileJson = tileJSON(
           pHeader,
-          await p.getMetadata(),
+          await pmtiles.getMetadata(),
           env.PUBLIC_HOSTNAME || url.hostname,
           name
         );
 
-        return cacheableResponse(JSON.stringify(t), cacheableHeaders, 200);
+        return cacheableResponse(
+          JSON.stringify(tileJson),
+          cacheableHeaders,
+          200
+        );
       }
 
       if (tile[0] < pHeader.minZoom || tile[0] > pHeader.maxZoom) {
@@ -185,6 +134,7 @@ export default {
             // allow this for now. Eventually we will delete this in favor of .mvt
             continue;
           }
+
           return cacheableResponse(
             `Bad request: requested .${ext} but archive has type .${pair[1]}`,
             cacheableHeaders,
@@ -193,7 +143,7 @@ export default {
         }
       }
 
-      const tiledata = await p.getZxy(tile[0], tile[1], tile[2]);
+      const tiledata = await pmtiles.getZxy(tile[0], tile[1], tile[2]);
 
       switch (pHeader.tileType) {
         case TileType.Mvt:
@@ -213,12 +163,75 @@ export default {
       if (tiledata) {
         return cacheableResponse(tiledata.data, cacheableHeaders, 200);
       }
+
       return cacheableResponse(undefined, cacheableHeaders, 204);
-    } catch (e) {
-      if (e instanceof KeyNotFoundError) {
+    } catch (error) {
+      if (error instanceof KeyNotFoundError) {
         return cacheableResponse("Archive not found", cacheableHeaders, 404);
       }
-      throw e;
+
+      throw error;
     }
   },
 };
+
+async function nativeDecompress(
+  buffer: ArrayBuffer,
+  compression: Compression
+): Promise<ArrayBuffer> {
+  if (compression === Compression.None || compression === Compression.Unknown) {
+    return buffer;
+  }
+
+  if (compression === Compression.Gzip) {
+    const stream = new Response(buffer).body;
+    const result = stream?.pipeThrough(new DecompressionStream("gzip"));
+    return new Response(result).arrayBuffer();
+  }
+
+  throw Error("Compression method not supported");
+}
+
+class R2Source implements Source {
+  env: Env;
+  archiveName: string;
+
+  constructor(env: Env, archiveName: string) {
+    this.env = env;
+    this.archiveName = archiveName;
+  }
+
+  getKey() {
+    return this.archiveName;
+  }
+
+  async getBytes(
+    offset: number,
+    length: number,
+    _signal?: AbortSignal,
+    etag?: string
+  ): Promise<RangeResponse> {
+    const response = await this.env.BUCKET.get(
+      pmtiles_path(this.archiveName, this.env.PMTILES_PATH),
+      {
+        range: { offset: offset, length: length },
+        onlyIf: { etagMatches: etag },
+      }
+    );
+
+    if (!response) {
+      throw new KeyNotFoundError("Archive not found");
+    }
+
+    if (!("body" in response) || !response.body) {
+      throw new EtagMismatch();
+    }
+
+    return {
+      data: await response.arrayBuffer(),
+      etag: response.etag,
+      cacheControl: response.httpMetadata?.cacheControl,
+      expires: response.httpMetadata?.cacheExpiry?.toISOString(),
+    };
+  }
+}

--- a/serverless/cloudflare/wrangler.toml.example
+++ b/serverless/cloudflare/wrangler.toml.example
@@ -9,4 +9,4 @@ r2_buckets  = [
 
 [vars]
 # ALLOWED_ORIGINS = "http://localhost:8000"
-# CACHE_MAX_AGE = 86400
+# CACHE_CONTROL = "public, max-age=86400"


### PR DESCRIPTION
Hey there

As [discussed](https://github.com/protomaps/PMTiles/discussions/404) I would like to deprecate the `CACHE_MAX_AGE` option in favour of `CACHE_CONTROL`. 

Users would then be able to set any `CACHE_CONTROL` directive they might need like `stale-while-revalidate` or `s-maxage`.

The change to add this feature would be rather small, however I had too much time on a train ride and improved a few things for readability. 

Changes:
- give variables meaningful names (avoid `o`, `p`, `a`, `e` etc.)
- restructure the file so one can read it from top to bottom (env first, globals, handler entrypoint, data source implementation)
- add types for environment variables in node.js
- remove type casts (type narrowing with `if`)
- use `function` keyword for all top level functions (instead of mixing `const fn = () => {}` and `function fn() {}`)

I know that my changes have gone a little far for this feature 😅, but I think this would also help future contributors (I'm open to split the PR in `feature` and `code readability`).

Thank you


