### PR TITLE
Add CACHE_CONTROL env, deprecate CACHE_MAX_AGE

### DIFF
--- a/serverless/aws/.gitignore
+++ b/serverless/aws/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -232,9 +232,9 @@ export const handlerRaw = async (
         data = tilePostprocess(data, header.tileType);
       }
 
-      headers["Cache-Control"] = `public, max-age=${
-        process.env.CACHE_MAX_AGE || 86400
-      }`;
+      headers["Cache-Control"] =
+        process.env.CACHE_CONTROL || "public, max-age=86400";
+
       headers.ETag = `"${createHash("sha256")
         .update(Buffer.from(data))
         .digest("hex")}"`;

--- a/serverless/cloudflare/src/index.ts
+++ b/serverless/cloudflare/src/index.ts
@@ -15,7 +15,7 @@ interface Env {
   // biome-ignore lint: config name
   BUCKET: R2Bucket;
   // biome-ignore lint: config name
-  CACHE_MAX_AGE?: number;
+  CACHE_CONTROL?: string;
   // biome-ignore lint: config name
   PMTILES_PATH?: string;
   // biome-ignore lint: config name
@@ -134,8 +134,9 @@ export default {
     ) => {
       cacheableHeaders.set(
         "Cache-Control",
-        `max-age=${env.CACHE_MAX_AGE || 86400}`
+        env.CACHE_CONTROL || "public, max-age=86400"
       );
+
       const cacheable = new Response(body, {
         headers: cacheableHeaders,
         status: status,

--- a/serverless/cloudflare/wrangler.toml.example
+++ b/serverless/cloudflare/wrangler.toml.example
@@ -9,4 +9,4 @@ r2_buckets  = [
 
 [vars]
 # ALLOWED_ORIGINS = "http://localhost:8000"
-# CACHE_MAX_AGE = 86400
+# CACHE_CONTROL = "public, max-age=86400"


### PR DESCRIPTION
Hey there

As [discussed](https://github.com/protomaps/PMTiles/discussions/404) I would like to deprecate the CACHE_MAX_AGE option in favour of CACHE_CONTROL.

Users would then be able to set any CACHE_CONTROL directive they might need like stale-while-revalidate or s-maxage.

Supersedes https://github.com/protomaps/PMTiles/pull/409