### PR TITLE
Prettier on JavaScript examples [#383]

### DIFF
--- a/js/examples/leaflet.html
+++ b/js/examples/leaflet.html
@@ -15,16 +15,19 @@
     <body>
         <div id="map"></div>
         <script type="text/javascript">
-            const map = L.map('map').setView([0, 0], 0);
+            const map = L.map("map").setView([0, 0], 0);
 
-            const p = new pmtiles.PMTiles("https://pmtiles.io/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles")
-            p.getHeader().then(h => {
-                let layer = pmtiles.leafletRasterLayer(p, {
-                    maxzoom:h.maxZoom,
-                    attribution:'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
-                });
-                layer.addTo(map);
-            })
+            const p = new pmtiles.PMTiles(
+              "https://pmtiles.io/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles"
+            );
+            p.getHeader().then((h) => {
+              let layer = pmtiles.leafletRasterLayer(p, {
+                maxzoom: h.maxZoom,
+                attribution:
+                  'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+              });
+              layer.addTo(map);
+            });
         </script>
     </body>
 </html>

--- a/js/examples/maplibre.html
+++ b/js/examples/maplibre.html
@@ -19,7 +19,7 @@
         <script type="text/javascript">
             // add the PMTiles plugin to the maplibregl global.
             let protocol = new pmtiles.Protocol();
-            maplibregl.addProtocol("pmtiles",protocol.tile);
+            maplibregl.addProtocol("pmtiles", protocol.tile);
 
             // pmtiles extract https://build.protomaps.com/20240807.pmtiles my_area.pmtiles --bbox=11.221144,43.745121,11.287543,43.789306
             let PMTILES_URL = "https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles";
@@ -30,65 +30,66 @@
             protocol.add(p);
 
             // we first fetch the header so we can get the center lon, lat of the map.
-            p.getHeader().then(h => {
-                const map = new maplibregl.Map({
-                    container: 'map',
-                    zoom: h.maxZoom-2,
-                    center: [h.centerLon, h.centerLat],
-                    style: {
-                        version:8,
-                        sources: {
-                            "example_source": {
-                                type: "vector",
-                                // For standard Z/X/Y tile APIs or Z/X/Y URLs served from go-pmtiles, replace "url" with "tiles" and remove all the pmtiles-related client code.
-                                // tiles: ["https://example.com/{z}/[x}/{y}.mvt"],
-                                // see https://maplibre.org/maplibre-style-spec/sources/#vector
-                                url: "pmtiles://" + PMTILES_URL,
-                                attribution: '© <a href="https://openstreetmap.org">OpenStreetMap</a>'
-                            }
-                        },
-                        layers: [
-                            {
-                                "id":"water",
-                                "source": "example_source",
-                                "source-layer":"water",
-                                "type": "fill",
-                                "paint": {
-                                    "fill-color": "#80b1d3"
-                                }
-                            },
-                            {
-                                "id":"buildings",
-                                "source": "example_source",
-                                "source-layer":"buildings",
-                                "type": "fill",
-                                "paint": {
-                                    "fill-color": "#d9d9d9"
-                                }
-                            },
-                            {
-                                "id":"roads",
-                                "source": "example_source",
-                                "source-layer":"roads",
-                                "type": "line",
-                                "paint": {
-                                    "line-color": "#fc8d62"
-                                }
-                            },
-                            {
-                                "id":"pois",
-                                "source": "example_source",
-                                "source-layer":"pois",
-                                "type": "circle",
-                                "paint": {
-                                    "circle-color": "#ffffb3"
-                                }
-                            }
-                        ]
-                    }
-                });
-                map.showTileBoundaries = true;
-            })
+            p.getHeader().then((h) => {
+              const map = new maplibregl.Map({
+                container: "map",
+                zoom: h.maxZoom - 2,
+                center: [h.centerLon, h.centerLat],
+                style: {
+                  version: 8,
+                  sources: {
+                    example_source: {
+                      type: "vector",
+                      // For standard Z/X/Y tile APIs or Z/X/Y URLs served from go-pmtiles, replace "url" with "tiles" and remove all the pmtiles-related client code.
+                      // tiles: ["https://example.com/{z}/[x}/{y}.mvt"],
+                      // see https://maplibre.org/maplibre-style-spec/sources/#vector
+                      url: "pmtiles://" + PMTILES_URL,
+                      attribution:
+                        '© <a href="https://openstreetmap.org">OpenStreetMap</a>',
+                    },
+                  },
+                  layers: [
+                    {
+                      id: "water",
+                      source: "example_source",
+                      "source-layer": "water",
+                      type: "fill",
+                      paint: {
+                        "fill-color": "#80b1d3",
+                      },
+                    },
+                    {
+                      id: "buildings",
+                      source: "example_source",
+                      "source-layer": "buildings",
+                      type: "fill",
+                      paint: {
+                        "fill-color": "#d9d9d9",
+                      },
+                    },
+                    {
+                      id: "roads",
+                      source: "example_source",
+                      "source-layer": "roads",
+                      type: "line",
+                      paint: {
+                        "line-color": "#fc8d62",
+                      },
+                    },
+                    {
+                      id: "pois",
+                      source: "example_source",
+                      "source-layer": "pois",
+                      type: "circle",
+                      paint: {
+                        "circle-color": "#ffffb3",
+                      },
+                    },
+                  ],
+                },
+              });
+              map.showTileBoundaries = true;
+            });
         </script>
     </body>
 </html>

--- a/js/examples/maplibre_raster_dem.html
+++ b/js/examples/maplibre_raster_dem.html
@@ -29,40 +29,51 @@
         </div>
         <script type="text/javascript">
             let protocol = new pmtiles.Protocol();
-            maplibregl.addProtocol("pmtiles",protocol.tile);
-            let URL = "https://r2-public.protomaps.com/protomaps-sample-datasets/terrarium_z9.pmtiles";
+            maplibregl.addProtocol("pmtiles", protocol.tile);
+            let URL =
+              "https://r2-public.protomaps.com/protomaps-sample-datasets/terrarium_z9.pmtiles";
 
-            function formatBytes(a,b=2){if(!+a)return"0 Bytes";const c=0>b?0:b,d=Math.floor(Math.log(a)/Math.log(1024));return`${parseFloat((a/Math.pow(1024,d)).toFixed(c))} ${["Bytes","KB","MB","GB","TB","PB","EB","ZB","YB"][d]}`}
+            function formatBytes(a, b = 2) {
+              if (!+a) return "0 Bytes";
+              const c = 0 > b ? 0 : b,
+                d = Math.floor(Math.log(a) / Math.log(1024));
+              return `${parseFloat((a / Math.pow(1024, d)).toFixed(c))} ${
+                ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d]
+              }`;
+            }
 
-            fetch(URL, {method:"HEAD"}).then(resp => {
-                let length = resp.headers.get("Content-Length");
-                document.getElementById("overlay").innerHTML = `<a href="${URL}">${URL}</a> (${formatBytes(length)})`;
-            })
+            fetch(URL, { method: "HEAD" }).then((resp) => {
+              let length = resp.headers.get("Content-Length");
+              document.getElementById(
+                "overlay"
+              ).innerHTML = `<a href="${URL}">${URL}</a> (${formatBytes(length)})`;
+            });
 
             const map = new maplibregl.Map({
-                container: 'map',
-                zoom: 0,
-                center: [0,0],
-                style: {
-                    version:8,
-                    sources: {
-                        "example_source": {
-                            type: "raster-dem",
-                            url: "pmtiles://" + URL,
-                            attribution: '<a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md">Tilezen Joerd: Attribution</a>',
-                            encoding:"terrarium"
-                        }
-                    },
-                    layers: [
-                        {
-                            "id":"dem",
-                            "source": "example_source",
-                            "source-layer":"landuse",
-                            "type": "hillshade"
-                        }
-                    ]
-                }
-            })
+              container: "map",
+              zoom: 0,
+              center: [0, 0],
+              style: {
+                version: 8,
+                sources: {
+                  example_source: {
+                    type: "raster-dem",
+                    url: "pmtiles://" + URL,
+                    attribution:
+                      '<a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md">Tilezen Joerd: Attribution</a>',
+                    encoding: "terrarium",
+                  },
+                },
+                layers: [
+                  {
+                    id: "dem",
+                    source: "example_source",
+                    "source-layer": "landuse",
+                    type: "hillshade",
+                  },
+                ],
+              },
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
Make the formatting of the JS examples consistent - quotations, spacing, etc. 