### PR TITLE
AWS updates

### DIFF
--- a/serverless/aws/protomaps-template.yaml
+++ b/serverless/aws/protomaps-template.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Serve Z/X/Y tiles through CloudFront + Lambda from an existing S3 bucket.
 Parameters:
   BucketName:
-    Description: 'Name of an existing S3 bucket with .pmtiles tilesets. Should be in the same region as your CloudFormation stack.'
+    Description: 'Name of an existing S3 bucket with .pmtiles tilesets. Should be in the same region as your CloudFormation stack. Can be a RequesterPays bucket in another account.'
     Type: String
     MinLength: 1
 

--- a/serverless/aws/protomaps-template.yaml
+++ b/serverless/aws/protomaps-template.yaml
@@ -6,6 +6,11 @@ Parameters:
     Type: String
     MinLength: 1
 
+  DefaultTTL:
+    Description: Default time-to-live for cached tiles in the CloudFront distribution.
+    Type: Number
+    Default: 86400
+
   AllowedOrigins:
     Description: 'Comma-separated list of domains (e.g. example.com) allowed by browser CORS policy, or * for all origins.'
     Type: List<String>
@@ -17,10 +22,11 @@ Parameters:
 
 Outputs:
   CloudFrontDistributionUrl:
-    Description: 'URL of the CloudFront distribution'
+    Description: 'URL of the CloudFront distribution for cached tiles.'
     Value: !Sub "https://${CloudFrontDistribution.DomainName}"
     Export:
       Name: !Sub "${AWS::StackName}-CloudFrontDistributionURL"
+
 
 Conditions:
   IsPublicHostnameProvided:
@@ -127,7 +133,7 @@ Resources:
     Properties:
       CachePolicyConfig:
         Name: !Sub "${AWS::StackName}-CachePolicyConfig"
-        DefaultTTL: 86400
+        DefaultTTL: !Ref DefaultTTL
         MaxTTL: 31536000
         MinTTL: 0
         ParametersInCacheKeyAndForwardedToOrigin:

--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -77,7 +77,8 @@ class S3Source implements Source {
           Range: "bytes=" + offset + "-" + (offset + length - 1),
           // biome-ignore lint: aws api
           IfMatch: etag,
-          RequestPayer: 'requester'
+          // biome-ignore lint: aws api
+          RequestPayer: "requester",
         })
       );
     } catch (e: unknown) {

--- a/serverless/aws/src/index.ts
+++ b/serverless/aws/src/index.ts
@@ -77,6 +77,7 @@ class S3Source implements Source {
           Range: "bytes=" + offset + "-" + (offset + length - 1),
           // biome-ignore lint: aws api
           IfMatch: etag,
+          RequestPayer: 'requester'
         })
       );
     } catch (e: unknown) {


### PR DESCRIPTION
* CloudFormation stack parameter for changing CloudFront tile cache TTL.
* S3 requests are always set as Requester Pays, enabling fetching from buckets in other accounts.
