### PR TITLE
add geometry filter to js examples because of v4 mixed geometries.

### DIFF
--- a/js/examples/maplibre.html
+++ b/js/examples/maplibre.html
@@ -43,6 +43,7 @@
                     id: "water",
                     source: "example_source",
                     "source-layer": "water",
+                    filter: ["==",["geometry-type"],"Polygon"],
                     type: "fill",
                     paint: {
                       "fill-color": "#80b1d3",

--- a/js/examples/maplibre_headers.html
+++ b/js/examples/maplibre_headers.html
@@ -55,6 +55,7 @@
                       id: "water",
                       source: "example_source",
                       "source-layer": "water",
+                      filter: ["==",["geometry-type"],"Polygon"],
                       type: "fill",
                       paint: {
                         "fill-color": "#80b1d3",


### PR DESCRIPTION
Fix #463 