### PR TITLE
NGI - Updating licensing aspects according to REUSE 

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/app/index.html
+++ b/app/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 Protomaps LLC
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/app/src/Inspector.tsx
+++ b/app/src/Inspector.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { VectorTile } from "@mapbox/vector-tile";
 import { path } from "d3-path";
 import { schemeSet3 } from "d3-scale-chromatic";

--- a/app/src/Loader.tsx
+++ b/app/src/Loader.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { useState } from "react";
 import { PMTiles } from "../../js/index";
 import { styled } from "./stitches.config";

--- a/app/src/MapView.tsx
+++ b/app/src/MapView.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React from "react";
 import reactDom from "react-dom/client";
 import MapViewComponent from "./MapViewComponent";

--- a/app/src/MapViewComponent.tsx
+++ b/app/src/MapViewComponent.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import React, { useState, useEffect } from "react";

--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import {
   LayerSpecification,
   StyleSpecification,

--- a/app/src/Metadata.tsx
+++ b/app/src/Metadata.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { JsonViewer } from "@textea/json-viewer";
 import { useEffect, useState } from "react";
 import { Header, PMTiles } from "../../js/index";

--- a/app/src/Start.tsx
+++ b/app/src/Start.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { Dispatch, SetStateAction, useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { FileSource, PMTiles } from "../../js/index";

--- a/app/src/TileInspect.tsx
+++ b/app/src/TileInspect.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React from "react";
 import reactDom from "react-dom/client";
 import TileInspectComponent from "./TileInspectComponent";

--- a/app/src/TileInspectComponent.tsx
+++ b/app/src/TileInspectComponent.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React, { useState, useEffect } from "react";
 import { PMTiles } from "../../js/index";
 import { globalStyles, styled } from "./stitches.config";

--- a/app/src/stitches.config.ts
+++ b/app/src/stitches.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { createStitches, globalCss } from "@stitches/react";
 
 export const { styled } = createStitches({

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 /// <reference types="vite/client" />

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Protomaps LLC
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";

--- a/python/examples/create_raster_example.py
+++ b/python/examples/create_raster_example.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Generates a raster tile archive for conformance testing.
 
 from urllib.request import Request, urlopen

--- a/python/pmtiles/__init__.py
+++ b/python/pmtiles/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from collections import namedtuple
 
 Entry = namedtuple("Entry", ["z", "x", "y", "offset", "length", "is_dir"])

--- a/python/pmtiles/convert.py
+++ b/python/pmtiles/convert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # pmtiles to files
 import gzip
 import json

--- a/python/pmtiles/reader.py
+++ b/python/pmtiles/reader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import json
 import mmap
 from .tile import (

--- a/python/pmtiles/tile.py
+++ b/python/pmtiles/tile.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from enum import Enum
 import io
 import gzip

--- a/python/pmtiles/v2.py
+++ b/python/pmtiles/v2.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import json
 from collections import namedtuple
 

--- a/python/pmtiles/writer.py
+++ b/python/pmtiles/writer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import json
 import tempfile
 import gzip

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import setuptools
 
 with open("README.md", "r") as fh:

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import unittest
 import sqlite3
 from io import BytesIO

--- a/python/test/test_reader_writer.py
+++ b/python/test/test_reader_writer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import unittest
 from io import BytesIO
 from pmtiles.writer import Writer

--- a/python/test/test_tile.py
+++ b/python/test/test_tile.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Protomaps LLC
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import unittest
 from pmtiles.tile import zxy_to_tileid, tileid_to_zxy, Entry
 from pmtiles.tile import read_varint, write_varint


### PR DESCRIPTION
Hello,

I work for the Free Software Foundation Europe (FSFE), and we have been working with the NGI framework, helping projects with their licensing and copyright management. After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information. **(Please keep in mind that this is simply a guideline for your project to consider)**. [REUSE](https://reuse.software/) is an FSFE-developed initiative intended to make licensing easier by establishing a single way to display all copyright and licensing information through comment headers on source files that can be human- and machine-readable.

## REUSE Features:
### Copyright and Licensing Information in each file

One of the main features of REUSE is that each file in the repository contains copyright and license information with the help of a comment header. To serve as a guideline and a practical example of how REUSE looks, I have added the header to some of the files in your repository e.g. `app/` `python/` but quite some other files still need such info. I've taken the copyright information from the `LICENSE `file. So, please double-check that the personal information in the headers is correct and consistent, otherwise, please update that information in the headers. 

Please, keep in mind that you can also change the [year in the headers](https://reuse.readthedocs.io/en/stable/man/reuse-annotate.html#cmdoption-y) depending on your [preference](https://reuse.software/faq/#years-copyright).

Please note that REUSE has also an option to add this legal information for [binary and uncommentable files](https://reuse.software/faq/#uncommentable-file) like` json` files, as well as for [insignificant files ](https://reuse.software/faq/#uncopyrightable) and no copyrightable files such as `.gitignore`. An appropriate license for the documentation files in your repository is also encouraged.

### LICENSES directory in the root of the project with the licenses used on the repository:

I included in this directory a file with the text of the BSD-3-Clause license. I did not do anything with the existing `LICENSE` file in the root of the directory. It is up to you if you want to keep it or delete it, however, this won't affect the REUSE specification. Please also be aware, that if some pieces of your project use a different license, such license text should be added to the `LICENSES/` directory as well as to the specific files.

Please feel free to check the [REUSE documentation](https://reuse.readthedocs.io/en/stable/) and the [helper tool ](https://reuse.software/dev/#tool), and if you are interested in making your project REUSE compliant, please add the legal information to the missing files. I am also available if you want support with the process.

## Wide range of tools

In case you find REUSE useful, we offer other tools to help you continuously check and display compliance with the REUSE guidelines. For instance, you can automatically run reuse lint on every commit as[ a pre-commit hook](https://reuse.software/dev/#pre-commit-hook) for Git. And, it can be easily [integrated into your existing CI/CD processes](https://reuse.software/dev/#ci) to continuously test your repository and its changes for REUSE compliance

Hope that helps and thank you very much for the amazing job!

I am happy to answer any question that you might have and happy to help in the process of helping your project to become REUSE compliant!