### PR TITLE
fix: use named export for better typing

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -1,6 +1,6 @@
 import { decompressSync } from "fflate";
 import v2 from "./v2";
-export * from "./adapters";
+export { Protocol, leafletRasterLayer } from "./adapters";
 
 /** @hidden */
 export interface BufferPosition {


### PR DESCRIPTION
Hi,

I use `pmtiles` module in TypeScript code like this and faced an error.

```typescript
import { Protocol } from 'pmtiles'; // Module '"pmtiles"' has no exported member 'Protocol'.
const protocol = new Protocol();
```

I guess `export * from "./adapters";` caused this and then re-write this with named export.
If it is okay, please merge this.