### PR TITLE
maplibre: display error on empty bounds [#508]

### DIFF
--- a/js/src/adapters.ts
+++ b/js/src/adapters.ts
@@ -221,6 +221,13 @@ export class Protocol {
       }
 
       const h = await instance.getHeader();
+
+      if (h.minLon >= h.maxLon || h.minLat >= h.maxLat) {
+        console.error(
+          `Bounds of PMTiles archive ${h.minLon},${h.minLat},${h.maxLon},${h.maxLat} are not valid.`
+        );
+      }
+
       return {
         data: {
           tiles: [`${params.url}/{z}/{x}/{y}`],


### PR DESCRIPTION
* If a MapLibre source has empty bounds, no tiles will be displayed.

See `bounds` section of the MapLibre docs: https://maplibre.org/maplibre-style-spec/sources/#bounds