### PR TITLE
Reuse toml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,11 @@
+The below license (BSD-3) applies to the reference implementations in this repository.
+
+The PMTiles specification itself is public domain, or CC0 where applicable.
+
+Sample tilesets available in this repository are subject to their own license terms.
+
+---
+
 Copyright 2021 Protomaps LLC
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,6 +1,21 @@
 version = 1
 
 [[annotations]]
-path = "**"
+path = ["app/**","cpp/**","js/**","openlayers/**","python/**","serverless/**"]
 SPDX-FileCopyrightText = "2021 and later, Protomaps LLC and contributors"
 SPDX-License-Identifier = "BSD-3-Clause"
+
+[[annotations]]
+path = "spec/**/*.md"
+SPDX-FileCopyrightText = "2021 and later, Protomaps LLC and contributors"
+SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = "spec/v3/protomaps(vector)ODbL_firenze.pmtiles"
+SPDX-FileCopyrightText = "© OpenStreetMap Contributors"
+SPDX-License-Identifier = "ODbL-1.0"
+
+[[annotations]]
+path = "stamen_toner(raster)CC-BY+ODbL_z3.pmtiles"
+SPDX-FileCopyrightText = "Stamen Design, © OpenStreetMap Contributors"
+SPDX-License-Identifier = "CC-BY-4.0"


### PR DESCRIPTION
Add a REUSE.toml with SPDX identifiers following https://reuse.software/spec-3.2/

Also clarify in LICENSE how terms apply to separate parts such as software, specification, tilesets. 

All software remains BSD-3, clarify in LICENSE that the specification itself (not software implementations) are public domain or CC-0 where applicable. However, sample tilesets in the `spec` folder may be ODbL, CC-BY or others.

In the future we should revise all sample tilesets distributed in this repo to be public domain or CC0 only (use USGS raster, Natural Earth only)

@nvkelso 