### PR TITLE
Simplify and optimize Hilbert tile ID <-> XYZ conversion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.associations": {
+    "*.svx": "svelte",
+    "bit": "cpp",
+    "limits": "cpp",
+    "stdexcept": "cpp"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "files.associations": {
-    "*.svx": "svelte",
-    "bit": "cpp",
-    "limits": "cpp",
-    "stdexcept": "cpp"
-  }
-}

--- a/cpp/pmtiles.hpp
+++ b/cpp/pmtiles.hpp
@@ -388,6 +388,7 @@ entryv3 find_tile(const std::vector<entryv3> &entries, uint64_t tile_id) {
 
 }  // end anonymous namespace
 
+// Note: std::bit_width is available in C++20 and later.
 static uint8_t bit_width(uint64_t n) {
     uint8_t count = 0;
     while (n > 0) { count++; n >>= 1; }

--- a/cpp/pmtiles.hpp
+++ b/cpp/pmtiles.hpp
@@ -321,13 +321,13 @@ uint64_t decode_varint(const char **data, const char *end) {
 	return decode_varint_impl(data, end);
 }
 
-void rotate(int64_t n, int64_t &x, int64_t &y, int64_t rx, int64_t ry) {
+void rotate(int64_t n, uint32_t &x, uint32_t &y, uint32_t rx, uint32_t ry) {
 	if (ry == 0) {
 		if (rx != 0) {
 			x = n - 1 - x;
 			y = n - 1 - y;
 		}
-		int64_t t = x;
+		uint32_t t = x;
 		x = y;
 		y = t;
 	}
@@ -402,11 +402,11 @@ inline zxy tileid_to_zxy(uint64_t tileid) {
 	uint8_t z = (bit_width(3 * tileid + 1) - 1) / 2;
 	uint64_t acc = ((1L << (z * 2)) - 1) / 3;
 	uint64_t pos = tileid - acc;
-	int64_t x = 0, y = 0;
+	uint32_t x = 0, y = 0;
 	for (uint8_t a = 0; a < z; a++) {
         uint64_t s = 1 << a;
-        uint64_t rx = s & (pos / 2);
-        uint64_t ry = s & (pos ^ rx);
+        uint32_t rx = s & (pos / 2);
+        uint32_t ry = s & (pos ^ rx);
 		rotate(s, x, y, rx, ry);
         pos >>= 1;
         x += rx;
@@ -423,13 +423,13 @@ inline uint64_t zxy_to_tileid(uint8_t z, uint32_t x, uint32_t y) {
 		throw std::overflow_error("tile x/y outside zoom level bounds");
 	}
 	uint64_t acc = ((1LL << (z * 2U)) - 1) / 3;
-	int64_t tx = x, ty = y;
+	uint32_t tx = x, ty = y;
 	int a = z - 1;
-	for (int64_t s = 1LL << a; s > 0; s >>= 1) {
-		int64_t rx = s & tx;
-		int64_t ry = s & ty;
+	for (uint32_t s = 1LL << a; s > 0; s >>= 1) {
+		uint32_t rx = s & tx;
+		uint32_t ry = s & ty;
 		rotate(s, tx, ty, rx, ry);
-		acc += ((3 * rx) ^ ry) << a;
+		acc += ((3LL * rx) ^ ry) << a;
 		a--;
 	}
 	return acc;

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -72,7 +72,6 @@ MU_TEST(test_roundtrip) {
 	} catch (const std::runtime_error &e) {
 		caught = true;
 	}
-
 	mu_check(caught);
 
 	caught = false;
@@ -81,7 +80,6 @@ MU_TEST(test_roundtrip) {
 	} catch (const std::runtime_error &e) {
 		caught = true;
 	}
-
 	mu_check(caught);
 
 	caught = false;
@@ -90,7 +88,6 @@ MU_TEST(test_roundtrip) {
 	} catch (const std::runtime_error &e) {
 		caught = true;
 	}
-
 	mu_check(caught);
 
 	caught = false;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -62,16 +62,17 @@ function rotate(
   rx: number,
   ry: number
 ): [number, number] {
+  let [tx, ty] = [x, y];
   if (ry === 0) {
     if (rx === 1) {
-      x = n - 1 - x;
-      y = n - 1 - y;
+      tx = n - 1 - tx;
+      ty = n - 1 - ty;
     }
-    const t = x;
-    x = y;
-    x = t;
+    const t = tx;
+    tx = ty;
+    tx = t;
   }
-  return [x, y];
+  return [tx, ty];
 }
 
 /**
@@ -84,12 +85,13 @@ export function zxyToTileId(z: number, x: number, y: number): number {
   if (x > 2 ** z - 1 || y > 2 ** z - 1) {
     throw new Error("tile x/y outside zoom level bounds");
   }
+  let [tx, ty] = [x, y];
   let acc = (4 ** z - 1) / 3;
   for (let a = z - 1; a >= 0; a--) {
-    const rx = (x >> a) & 1;
-    const ry = (y >> a) & 1;
+    const rx = (tx >> a) & 1;
+    const ry = (ty >> a) & 1;
     const s = 2 ** a;
-    [x, y] = rotate(s, x, y, rx, ry);
+    [tx, ty] = rotate(s, tx, ty, rx, ry);
     acc += s * s * ((3 * rx) ^ ry);
   }
   return acc;
@@ -102,7 +104,7 @@ export function tileIdToZxy(i: number): [number, number, number] {
   const z = Math.floor(Math.log2(3 * i + 1)) >> 1;
   if (z > 26)
     throw new Error("Tile zoom level exceeds max safe number limit (26)");
-  let acc = (4 ** z - 1) / 3;
+  const acc = (4 ** z - 1) / 3;
   let pos = i - acc;
   let x = 0;
   let y = 0;

--- a/python/pmtiles/tile.py
+++ b/python/pmtiles/tile.py
@@ -1,6 +1,6 @@
-from enum import Enum
-import io
 import gzip
+import io
+from enum import Enum
 
 
 class Entry:
@@ -16,28 +16,13 @@ class Entry:
         return f"id={self.tile_id} offset={self.offset} length={self.length} runlength={self.run_length}"
 
 
-def rotate(n, xy, rx, ry):
+def rotate(n, x, y, rx, ry):
     if ry == 0:
         if rx == 1:
-            xy[0] = n - 1 - xy[0]
-            xy[1] = n - 1 - xy[1]
-        xy[0], xy[1] = xy[1], xy[0]
-
-
-def t_on_level(z, pos):
-    n = 1 << z
-    rx, ry, t = pos, pos, pos
-    xy = [0, 0]
-    s = 1
-    while s < n:
-        rx = 1 & (t // 2)
-        ry = 1 & (t ^ rx)
-        rotate(s, xy, rx, ry)
-        xy[0] += s * rx
-        xy[1] += s * ry
-        t //= 4
-        s *= 2
-    return z, xy[0], xy[1]
+            x = n - 1 - x
+            y = n - 1 - y
+        x, y = y, x
+    return x, y
 
 
 def zxy_to_tileid(z, x, y):
@@ -45,41 +30,34 @@ def zxy_to_tileid(z, x, y):
         raise OverflowError("tile zoom exceeds 64-bit limit")
     if x > (1 << z) - 1 or y > (1 << z) - 1:
         raise ValueError("tile x/y outside zoom level bounds")
-    acc = 0
-    tz = 0
-    while tz < z:
-        acc += (0x1 << tz) * (0x1 << tz)
-        tz += 1
-    n = 1 << z
-    rx = 0
-    ry = 0
-    d = 0
-    xy = [x, y]
-    s = n // 2
-    while s > 0:
-        if (xy[0] & s) > 0:
-            rx = 1
-        else:
-            rx = 0
-        if (xy[1] & s) > 0:
-            ry = 1
-        else:
-            ry = 0
-        d += s * s * ((3 * rx) ^ ry)
-        rotate(s, xy, rx, ry)
-        s //= 2
-    return acc + d
+
+    acc = ((1 << (z * 2)) - 1) // 3
+    for a in reversed(range(0, z)):
+        rx = (x >> a) & 1
+        ry = (y >> a) & 1
+        s = 1 << a
+        (x, y) = rotate(s, x, y, rx, ry)
+        acc += s * s * ((3 * rx) ^ ry)
+    return acc
 
 
 def tileid_to_zxy(tile_id):
-    num_tiles = 0
-    acc = 0
-    for z in range(0,32):
-        num_tiles = (1 << z) * (1 << z)
-        if acc + num_tiles > tile_id:
-            return t_on_level(z, tile_id - acc)
-        acc += num_tiles
-    raise OverflowError("tile zoom exceeds 64-bit limit")
+    z = ((3 * tile_id + 1).bit_length() - 1) // 2
+    if z >= 32:
+        raise OverflowError("tile zoom exceeds 64-bit limit")
+    acc = ((1 << (z * 2)) - 1) // 3
+    pos = tile_id - acc
+    x = 0
+    y = 0
+    for a in range(0, z):
+        rx = (pos // 2) & 1
+        ry = (pos ^ rx) & 1
+        s = 1 << a
+        (x, y) = rotate(s, x, y, rx, ry)
+        pos //= 4
+        x += s * rx
+        y += s * ry
+    return (z, x, y)
 
 
 def find_tile(entries, tile_id):
@@ -195,11 +173,14 @@ def serialize_directory(entries):
 
     return gzip.compress(b_io.getvalue())
 
+
 class SpecVersionUnsupported(Exception):
     pass
 
+
 class MagicNumberNotFound(Exception):
     pass
+
 
 def deserialize_header(buf):
     if buf[0:7].decode() != "PMTiles":
@@ -282,7 +263,7 @@ def serialize_header(h):
     write_int32(max_lon_e7)
     max_lat_e7 = h.get("max_lat_e7", int(90 * 10000000))
     write_int32(max_lat_e7)
-    write_uint8(h.get("center_zoom",h["min_zoom"]))
+    write_uint8(h.get("center_zoom", h["min_zoom"]))
     write_int32(h.get("center_lon_e7", round((min_lon_e7 + max_lon_e7) / 2)))
     write_int32(h.get("center_lat_e7", round((min_lat_e7 + max_lat_e7) / 2)))
 

--- a/python/pmtiles/tile.py
+++ b/python/pmtiles/tile.py
@@ -18,7 +18,7 @@ class Entry:
 
 def rotate(n, x, y, rx, ry):
     if ry == 0:
-        if rx == 1:
+        if rx != 0:
             x = n - 1 - x
             y = n - 1 - y
         x, y = y, x
@@ -32,12 +32,14 @@ def zxy_to_tileid(z, x, y):
         raise ValueError("tile x/y outside zoom level bounds")
 
     acc = ((1 << (z * 2)) - 1) // 3
-    for a in reversed(range(0, z)):
-        rx = (x >> a) & 1
-        ry = (y >> a) & 1
+    a = z - 1
+    while a >= 0:
         s = 1 << a
+        rx = s & x
+        ry = s & y
+        acc += ((3 * rx) ^ ry) << a
         (x, y) = rotate(s, x, y, rx, ry)
-        acc += s * s * ((3 * rx) ^ ry)
+        a -= 1
     return acc
 
 
@@ -49,14 +51,16 @@ def tileid_to_zxy(tile_id):
     pos = tile_id - acc
     x = 0
     y = 0
-    for a in range(0, z):
-        rx = (pos // 2) & 1
-        ry = (pos ^ rx) & 1
-        s = 1 << a
+    s = 1
+    n = 1 << z
+    while s < n:
+        rx = (pos // 2) & s
+        ry = (pos ^ rx) & s
         (x, y) = rotate(s, x, y, rx, ry)
-        pos //= 4
-        x += s * rx
-        y += s * ry
+        x += rx
+        y += ry
+        pos >>= 1
+        s <<= 1
     return (z, x, y)
 
 


### PR DESCRIPTION
I found that we can simplify and optimize the conversion between XYZ tile coordinates and the Hilbert tile IDs.

This optimization is primarily based on the fact that the tile IDs for (zi, 0, 0) are given by the sum of a geometric series with a common ratio of 4.

Related PR: https://github.com/protomaps/go-pmtiles/pull/208