### PR TITLE
app: disable pointer events on popup unless it is frozen

### DIFF
--- a/app/src/MaplibreMap.tsx
+++ b/app/src/MaplibreMap.tsx
@@ -460,6 +460,9 @@ function MaplibreMap(props: { file: PMTiles; mapHashPassed: boolean }) {
     });
 
     map.on("click", (e) => {
+      popupFrozen
+        ? popup.removeClassName("frozen")
+        : popup.addClassName("frozen");
       setPopupFrozen((p) => !p);
     });
 

--- a/app/src/stitches.config.ts
+++ b/app/src/stitches.config.ts
@@ -61,4 +61,10 @@ export const globalStyles = globalCss({
     color: "$white",
     fontFamily: "sans-serif",
   },
+  ".maplibregl-popup .maplibregl-popup-content": {
+    pointerEvents: "none",
+  },
+  ".maplibregl-popup.frozen .maplibregl-popup-content": {
+    pointerEvents: "auto",
+  },
 });


### PR DESCRIPTION
This PR fixes a minor rough edge in the PMTiles Viewer app. When moving the mouse quickly across the map, it was possible for the cursor to enter the popup area, which intercepted pointer events. This would cause the popup to unexpectedly get "stuck" when it was supposed to be following the cursor around, and require you to move the cursor outside of the popup again to unstick it.

The fix is to apply `pointer-events: none` to the popup. But since it's also useful to be able to select text in the popup (to copy an attribute value for example), I only apply this CSS property when the popup is not frozen.