### PR TITLE
Toggle visibility of the label layer for line data

### DIFF
--- a/app/src/PageMap.tsx
+++ b/app/src/PageMap.tsx
@@ -284,6 +284,7 @@ function MapView(props: {
       setVisibility(`tileset_fill_${id}`, visibility);
       setVisibility(`tileset_line_${id}`, visibility);
       setVisibility(`tileset_circle_${id}`, visibility);
+      setVisibility(`tileset_line_label_${id}`, visibility);
       setVisibility(`tileset_point_label_${id}`, visibility);
     }
   });


### PR DESCRIPTION
When a PMTile layer has a line and has a property of `name`, the PMTiles viewer will draw label.  

This PR fixes the Bug:  *Label still showing when line layer is turned off.*

--- 

*Current PMTiles.io:  line layer is disabled, but label still shows*

<img width=33% src="https://github.com/user-attachments/assets/e69aba5c-27c5-4e5e-80cc-5723d5522d33">
 | 
<img width=33% src="https://github.com/user-attachments/assets/a40c1464-40ca-4c92-9f62-799900f5aed9">

---

*After this PR:  when disabling a line layer via checkbox, both the line & label properly have no `visibility`*
<img width=33% src="https://github.com/user-attachments/assets/2275c612-0a96-4556-b2c0-fd461fdff503">
