### PR TITLE
Add a label to a polygon with `name`

### DIFF
--- a/app/src/PageMap.tsx
+++ b/app/src/PageMap.tsx
@@ -284,6 +284,7 @@ function MapView(props: {
       setVisibility(`tileset_fill_${id}`, visibility);
       setVisibility(`tileset_line_${id}`, visibility);
       setVisibility(`tileset_circle_${id}`, visibility);
+      setVisibility(`tileset_line_label_${id}`, visibility);
       setVisibility(`tileset_point_label_${id}`, visibility);
     }
   });

--- a/app/src/PageMap.tsx
+++ b/app/src/PageMap.tsx
@@ -219,6 +219,30 @@ function MapView(props: {
           },
           filter: ["==", ["geometry-type"], "Point"],
         });
+        map.addLayer({
+          id: `tileset_polygon_label_${vectorLayer}`,
+          type: "symbol",
+          source: "tileset",
+          "source-layer": vectorLayer,
+          layout: {
+            "text-field": ["get", "name"],
+            "text-font": ["Noto Sans Regular"],
+            "text-max-angle": 85,
+            "text-offset": [0, 1],
+            "text-anchor": "bottom",
+            "text-rotation-alignment": "map",
+            "text-keep-upright": true,
+            "text-size": 10,
+            "symbol-placement": "line",
+            "symbol-spacing": 250,
+          },
+          paint: {
+            "text-color": colorForIdx(i),
+            "text-halo-color": flavor,
+            "text-halo-width": 2,
+          },
+          filter: ["==", ["geometry-type"], "Polygon"],
+        });
       }
     } else {
       map.addSource("tileset", {
@@ -286,6 +310,7 @@ function MapView(props: {
       setVisibility(`tileset_circle_${id}`, visibility);
       setVisibility(`tileset_line_label_${id}`, visibility);
       setVisibility(`tileset_point_label_${id}`, visibility);
+      setVisibility(`tileset_polygon_label_${id}`, visibility);
     }
   });
 


### PR DESCRIPTION
If a feature layer is either a point or line and has the property `name`, then PMTiles Viewer will draw a label. 


This PR now includes a polygon, by drawing the label on the inside border of the polygon.

*Example:  the Joshua Tree Wilderness is split by a road.*

<img width=50% src="https://github.com/user-attachments/assets/128084df-5cae-422a-abaf-d08c7fe2d0fa">

---

*Example:  the Mojave Wilderness is split by a rail line.*

<img width=50% src="https://github.com/user-attachments/assets/f901562f-d14d-4fd7-b881-c44065e69065">
