### PR TITLE
Update docs for `rio-pmtiles`

### DIFF
--- a/python/rio-pmtiles/README.rst
+++ b/python/rio-pmtiles/README.rst
@@ -45,8 +45,8 @@ Usage
       -o, --output PATH               Path to output file (optional alternative to
                                       a positional arg).
 
-      --description TEXT              PMTiles dataset description.
       --name TEXT                     PMTiles metadata name.
+      --description TEXT              PMTiles metadata description.
       --overlay                       Export as an overlay (the default).
       --baselayer                     Export as a base layer.
       -f, --format [JPEG|PNG|WEBP]    Tile image format.  [default: WEBP]

--- a/python/rio-pmtiles/README.rst
+++ b/python/rio-pmtiles/README.rst
@@ -49,9 +49,9 @@ Usage
       --description TEXT              PMTiles dataset description.
       --overlay                       Export as an overlay (the default).
       --baselayer                     Export as a base layer.
-      -f, --format [JPEG|PNG|WEBP]    Tile image format.
+      -f, --format [JPEG|PNG|WEBP]    Tile image format.  [default: WEBP]
       --tile-size INTEGER             Width and height of individual square tiles
-                                      to create.  [default: 256]
+                                      to create.  [default: 512]
 
       --zoom-levels MIN..MAX          A min...max range of export zoom levels. The
                                       default zoom level is the one at which the
@@ -64,7 +64,7 @@ Usage
       --dst-nodata FLOAT              Manually override destination nodata
       --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss|max|min|med|q1|q3|rms]
                                       Resampling method to use.  [default:
-                                      nearest]
+                                      bilinear]
 
       --version                       Show the version and exit.
       --rgba                          Select RGBA output. For PNG or WEBP only.

--- a/python/rio-pmtiles/README.rst
+++ b/python/rio-pmtiles/README.rst
@@ -45,8 +45,8 @@ Usage
       -o, --output PATH               Path to output file (optional alternative to
                                       a positional arg).
 
-      --title TEXT                    PMTiles dataset title.
       --description TEXT              PMTiles dataset description.
+      --name TEXT                     PMTiles metadata name.
       --overlay                       Export as an overlay (the default).
       --baselayer                     Export as a base layer.
       -f, --format [JPEG|PNG|WEBP]    Tile image format.  [default: WEBP]


### PR DESCRIPTION
After reviewing the tool `rio-pmtiles` and doing some _ad hoc_ testing, I have a couple of edits for the next release of the docs:

* The docs at https://docs.protomaps.com/pmtiles/create#geotiff mention some the defaults (`WEBP`, `512` & `bilinear`)
  * but that info is out of the date with https://pypi.org/project/rio-pmtiles 
  * and the actual source code [python/rio-pmtiles/README.rst](python/rio-pmtiles/README.rst)

---
Commit notes
* Commit 6027eb75c9dbee3723926e835b93ab956c32bfef is intended to have the defaults match those mentioned at  `docs.protomaps.com`
* Commit 7b969c0df87a1c79dede2f8fd5340118eab82c58 is a fix for a broken flag, `--title` did not work nor matched code.   The published flag is now `--name` and does work with a live GeoTIFF
* Commit 3eb61554ff25568965fe7a521cdc47e1e6c4441a is a minor change to sync verbiage used in  `cli.py` 

---

BTW,  `rio-pmtiles` is an excellent way to cut GeoTIFF's.  So thank you for that feature.  Simpler to use than GDAL & QGIS for rasters that start out as a GeoTIFF.

#### *Escondido quad, 1948 from USGS*
```
name:  "USGS"
type:  "overlay"
description:  "Escondido 1948"
writer:  "rio-pmtiles 1.0.0"
```

![image](https://github.com/user-attachments/assets/ce7f7ec7-425a-46a1-9cfc-164a9758566e)

Generated by:

```bash
rio pmtiles \
--name USGS \
--description "Escondido 1948" \
--output out.pmtiles \
  CA_Escondido_290379_1948_24000_geo.tif
```