### PR TITLE
rio pmtiles:  Add "PMTiles metadata attribution" to the Python code

### DIFF
--- a/python/rio-pmtiles/README.rst
+++ b/python/rio-pmtiles/README.rst
@@ -47,6 +47,7 @@ Usage
 
       --name TEXT                     PMTiles metadata name.
       --description TEXT              PMTiles metadata description.
+      --attribution TEXT              PMTiles metadata attribution.
       --overlay                       Export as an overlay (the default).
       --baselayer                     Export as a base layer.
       -f, --format [JPEG|PNG|WEBP]    Tile image format.  [default: WEBP]

--- a/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
+++ b/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
@@ -120,6 +120,7 @@ def guess_maxzoom(crs, bounds, width, height, tile_size):
 @output_opt
 @click.option("--name", help="PMTiles metadata name.")
 @click.option("--description", help="PMTiles metadata description.")
+@click.option("--attribution", help="PMTiles metadata attribution.")
 @click.option(
     "--overlay",
     "layer_type",
@@ -226,6 +227,7 @@ def pmtiles(
     output,
     name,
     description,
+    attribution,
     layer_type,
     img_format,
     tile_size,
@@ -300,6 +302,7 @@ def pmtiles(
             # Name and description.
             name = name or os.path.basename(src.name)
             description = description or src.name
+            attribution = attribution or None
 
             # Compute the geographic bounding box of the dataset.
             (west, east), (south, north) = transform(
@@ -374,7 +377,7 @@ def pmtiles(
         outfile.write(b"\x00" * 16384)
         entries = []
 
-        metadata = gzip.compress(json.dumps({'name':name,'type':layer_type,'description':description,'writer':f'rio-pmtiles {rio_pmtiles_version}'}).encode())
+        metadata = gzip.compress(json.dumps({'name':name,'type':layer_type,'description':description,'writer':f'rio-pmtiles {rio_pmtiles_version}','attribution':attribution}).encode())
         outfile.write(metadata)
 
         header = {}

--- a/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
+++ b/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
@@ -377,7 +377,7 @@ def pmtiles(
         outfile.write(b"\x00" * 16384)
         entries = []
 
-        metadata = gzip.compress(json.dumps({'name':name,'type':layer_type,'description':description,'writer':f'rio-pmtiles {rio_pmtiles_version}','attribution':attribution}).encode())
+        metadata = gzip.compress(json.dumps({'name':name,'type':layer_type,'description':description,'writer':f'rio-pmtiles {rio_pmtiles_version}','attribution':attribution,'tileSize':int(tile_size)}).encode())
         outfile.write(metadata)
 
         header = {}


### PR DESCRIPTION
**Summary**:  Adds an attribution to the PMTiles metadata if using `rio pmtiles --attribution`

* The plugin for the Rasterio CLI now matches the [TileJSON 3.0.0 spec#3.4](https://github.com/mapbox/tilejson-spec/blob/master/3.0.0/README.md#34-attribution).  
* Spec says:  "*OPTIONAL. String. Default: null*" 
* I made a choice to have the Metadata be either
  * Case:  Default
    * `"attribution": null`
    * If using `pmtiles show --metadata`, then give a clue that attribution could be set, but it is null.
  * Case:  OPTIONAL
    * Or, `"attribution": "what ever you passed in"`

---

Metadata+Attribution Test 1:  
* `rio pmtiles INPUT OUTPUT`
* with no `--attribution` passed in

```json
{
  "name": "Build-Lebanon-Trails-2x3.tif",
  "type": "overlay",
  "description": "/tmp/Build-Lebanon-Trails-2x3.tif",
  "writer": "rio-pmtiles 1.0.1-robc",
  "attribution": null
}
```

---

Metadata+Attribution Test 2:  
* `rio pmtiles INPUT OUTPUT`
* with `--attribution '📍 Attribution 🌐'`

```json
{
  "name": "Build-Lebanon-Trails-2x3.tif",
  "type": "overlay",
  "description": "/tmp/Build-Lebanon-Trails-2x3.tif",
  "writer": "rio-pmtiles 1.0.1-robc",
  "attribution": "📍 Attribution 🌐"
}
```