### PR TITLE
chore(docs): update stale README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [go-pmtiles](https://github.com/protomaps/go-pmtiles) repository.
 
 ### Python
 
-See https://github.com/protomaps/PMTiles/tree/main/python/bin for library usage
+See [pmtiles scripts](https://github.com/protomaps/PMTiles/tree/main/python/pmtiles/bin) for library usage
 
 ### Serverless
 


### PR DESCRIPTION
While reviewing the documentation, I noticed a stale URL referencing the Python scripts. This update hopefully fixes the link to point to the correct path.

I wasn’t able to find any contribution guidelines, so please let me know if there’s a specific process (e.g., opening an issue first) that I should follow to align with the project’s standards.