### PR TITLE
Add intelligent overview selection for tif to pmtiles conversion

### DIFF
--- a/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
+++ b/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
@@ -335,11 +335,12 @@ def pmtiles(
                 warp_options["cutline"] = shapely.wkt.dumps(cutline_rev)
 
         # Resolve the minimum and maximum zoom levels for export.
+        maxzoom_in_file = guess_maxzoom(src.crs, src.bounds, src.width, src.height, tile_size)
         if zoom_levels:
             minzoom, maxzoom = map(int, zoom_levels.split(".."))
         else:
             minzoom = 0
-            maxzoom = guess_maxzoom(src.crs, src.bounds, src.width, src.height, tile_size)
+            maxzoom = maxzoom_in_file
 
         log.debug("Zoom range: %d..%d", minzoom, maxzoom)
 
@@ -442,6 +443,7 @@ def pmtiles(
                 warp_options,
                 creation_options,
                 exclude_empty_tiles,
+                maxzoom_in_file,
             ),
         ) as executor:
             for tile, contents in executor.map(process_tile, unwrap_tiles(tiles)):

--- a/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
+++ b/python/rio-pmtiles/rio_pmtiles/scripts/cli.py
@@ -359,7 +359,7 @@ def pmtiles(
             {
                 "driver": img_format.upper(),
                 "dtype": "uint8",
-                "nodata": 0,
+                "nodata": 255 if rgba else 0,
                 "height": tile_size,
                 "width": tile_size,
                 "count": count,

--- a/python/rio-pmtiles/rio_pmtiles/worker.py
+++ b/python/rio-pmtiles/rio_pmtiles/worker.py
@@ -62,13 +62,13 @@ def process_tile(tile):
     temp_src = rasterio.open(filename)
     overviews = temp_src.overviews(1)
     temp_src.close()
-    overview_level = 0
+    overview_level = None
     if overviews and tile.z < max_zoom_level:
         OVERSAMPLING_FACTOR = 4  # oversampling factor to ensure sufficient pixels for resampling operations
         target_factor = 2 ** (max_zoom_level - tile.z) / OVERSAMPLING_FACTOR
-        best_overview = 0
+        best_overview = overview_level
         best_score = float("inf")
-        for i_overview, factor in enumerate(overviews, start=1):
+        for i_overview, factor in enumerate(overviews):
             if factor <= target_factor:
                 score = abs(factor - target_factor)
                 if score < best_score:
@@ -76,7 +76,7 @@ def process_tile(tile):
                     best_overview = i_overview
         overview_level = best_overview
 
-    if overview_level > 0:
+    if overview_level is not None:
         open_options["OVERVIEW_LEVEL"] = overview_level
 
     with rasterio.open(filename, **open_options) as src:


### PR DESCRIPTION
Hi there,

First, thanks for all the work on the PMTiles format, it's so nice to use.

I noticed that, when using the `rio-pmtiles` package to convert large tiff files to pmtiles, I had performance issues. It took me a while to understand why: when generating low-zoom tiles from large GeoTIFFs, the current `reproject` function of rasterio doesn't load the overviews (see https://rasterio.groups.io/g/main/topic/does_rasterio_warp_reproject/78009234). So it loads "full detail" data on very large extents to compute the overviews: it's very slow and uses lots of memory.

This PR implements a fix by specifying the `OVERVIEW_LEVEL` which needs to be loaded before the `reproject` function call.

Changes:
- CLI: Compute source file's native zoom level and pass to workers (needed to compute the overview level)
- Worker: Compute and use `OVERVIEW_LEVEL` to read appropriate overviews instead of full resolution

Additional small fix:
- Use nodata=255 for RGBA inputs/outputs to prevent warnings by GDAL during conversion like:
  `Warning 1: Value 0 in the source dataset has been changed to 1 in the destination dataset to avoid being treated as NoData. To avoid this, select a different NoData value for the destination dataset.`

> Note: for quick testing you can install it from my fork using:
> ```bash
> pip install -e "git+https://github.com/qchenevier/PMTiles#egg=rio-pmtiles&subdirectory=python/rio-pmtiles"
> ```