### PR TITLE
Update Lambda permissions and runtime version

### DIFF
--- a/serverless/aws/protomaps-template.yaml
+++ b/serverless/aws/protomaps-template.yaml
@@ -80,7 +80,9 @@ Resources:
   LambdaFunctionUrlPermission:
     Type: 'AWS::Lambda::Permission'
     Properties:
-      Action: lambda:InvokeFunctionUrl
+      Action:
+        - lambda:InvokeFunctionUrl
+        - lambda:InvokeFunction
       FunctionName: !Ref LambdaFunction
       Principal: '*'
       FunctionUrlAuthType: NONE
@@ -174,7 +176,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       FunctionName: !Sub "${AWS::StackName}-LambdaFunction"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Architectures: [arm64]
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler


### PR DESCRIPTION
Updates the Lambda configuration following two recent announcements from AWS. 

First, AWS notified us that Node.js 20 is reaching end of life, so the function runtime has been upgraded from `nodejs20.x` to `nodejs22.x` to stay current.

Second, AWS announced a change to the authorization model for Lambda Function URLs. They now require functions to allow both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` for the URL to keep working. Previously we only needed the first one. This update adds the missing permission so that the Function URL remains compatible with the new rules before the 2026 deadline.

------

<img width="575" height="185" alt="Screenshot 2025-11-18 at 10 31 04" src="https://github.com/user-attachments/assets/bf42e9a4-1a68-4af2-bd80-fafa82a94e7c" />

------

<img width="570" height="143" alt="Screenshot 2025-11-18 at 10 31 25" src="https://github.com/user-attachments/assets/c6a182f9-7c38-4764-b1c0-8acbdcb79e06" />