### PR TITLE
Fix Lambda permissions in protomaps-template.yaml

### DIFF
--- a/serverless/aws/protomaps-template.yaml
+++ b/serverless/aws/protomaps-template.yaml
@@ -77,15 +77,20 @@ Resources:
       TargetFunctionArn: !GetAtt LambdaFunction.Arn
       InvokeMode: BUFFERED
 
-  LambdaFunctionUrlPermission:
-    Type: 'AWS::Lambda::Permission'
+  LambdaFunctionUrlPermissionInvokeUrl:
+    Type: AWS::Lambda::Permission
     Properties:
-      Action:
-        - lambda:InvokeFunctionUrl
-        - lambda:InvokeFunction
+      Action: lambda:InvokeFunctionUrl
       FunctionName: !Ref LambdaFunction
       Principal: '*'
       FunctionUrlAuthType: NONE
+
+  LambdaFunctionUrlPermissionInvokeFunction:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaFunction
+      Principal: '*'
 
   ViewerRequestCloudFrontFunction:
     Type: AWS::CloudFront::Function


### PR DESCRIPTION
Hey @bdon,

After you merged, I tested my changes from https://github.com/protomaps/PMTiles/pull/605 and encountered the following error:

> Properties validation failed for resource LambdaFunctionUrlPermission with message: [#/Action: expected type: String, found: JSONArray]

Apparently CloudFormation only accepts one action per Permission resource. This PR fixes that issue. I’ve tested it, and everything now works as expected. My apologies for not adequately testing the previous change.