### PR TITLE
Update `leafletRasterLayer` to dispatch empty image if no raster data

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.5.3",
         "@types/leaflet": "^1.9.8",
-        "@types/node": "^20.0.0",
+        "@types/node": "^20.19.26",
         "msw": "^2.5.0",
         "tsup": "^8.4.0",
         "tsx": "^4.19.3",
@@ -1197,13 +1197,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.3.tgz",
-      "integrity": "sha512-tSQrmKKatLDGnG92h40GD7FzUt0MjahaHwOME4VAFeeA/Xopayq5qLyQRy7Jg/pjgKIFBXuKcGhJo+UdYG55jQ==",
+      "version": "20.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
+      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/statuses": {
@@ -1292,10 +1293,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1500,6 +1502,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1950,6 +1953,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2440,6 +2444,7 @@
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -2494,6 +2499,7 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2503,9 +2509,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3285,12 +3291,13 @@
       }
     },
     "@types/node": {
-      "version": "20.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.3.tgz",
-      "integrity": "sha512-tSQrmKKatLDGnG92h40GD7FzUt0MjahaHwOME4VAFeeA/Xopayq5qLyQRy7Jg/pjgKIFBXuKcGhJo+UdYG55jQ==",
+      "version": "20.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
+      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/statuses": {
@@ -3356,9 +3363,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
@@ -3498,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
       "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.25.0",
         "@esbuild/android-arm": "0.25.0",
@@ -3804,7 +3812,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "pirates": {
       "version": "4.0.6",
@@ -4112,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "~0.25.0",
         "fsevents": "~2.3.3",
@@ -4140,12 +4150,13 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "universalify": {

--- a/js/package.json
+++ b/js/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",
     "@types/leaflet": "^1.9.8",
-    "@types/node": "^20.0.0",
+    "@types/node": "^20.19.26",
     "msw": "^2.5.0",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",

--- a/js/src/adapters.ts
+++ b/js/src/adapters.ts
@@ -57,8 +57,11 @@ export const leafletRasterLayer = (source: PMTiles, options: unknown) => {
             const imageUrl = window.URL.createObjectURL(blob);
             el.src = imageUrl;
             el.cancel = undefined;
-            done(undefined, el);
-          }
+          }else{
+	    el.style.display = "none";		
+            el.cancel = undefined;	  
+	  }
+          done(undefined, el);		  
         })
         .catch((e) => {
           if (e.name !== "AbortError") {


### PR DESCRIPTION
* Update`leafletRasterLayer` to dispatch empty image if `source.getZxy` returns an empty array (no raster data). 
* Run `npm audit fix`

This change means that the `done` callback is always invoked, which is dispatched by the Leaflet.GridLayer `_tileReady` thus ensuring that the layer's "load" event will be fired correctly.