### PR TITLE
Fix pmtiles::tileid_to_zxy for platforms where "long" is 32bit

### DIFF
--- a/cpp/pmtiles.hpp
+++ b/cpp/pmtiles.hpp
@@ -401,7 +401,7 @@ inline zxy tileid_to_zxy(uint64_t tileid) {
 		throw std::overflow_error("tile zoom exceeds 64-bit limit");
 	}
 	uint8_t z = (bit_width(3 * tileid + 1) - 1) / 2;
-	uint64_t acc = ((1L << (z * 2)) - 1) / 3;
+	uint64_t acc = ((1LL << (z * 2)) - 1) / 3;
 	uint64_t pos = tileid - acc;
 	uint32_t x = 0, y = 0;
 	for (uint8_t a = 0; a < z; a++) {


### PR DESCRIPTION
`pmtiles::tileid_to_zxy` is incorrect on platforms where "long" is 32bit a.k.a. Windows for tiles with Z >= 16. This PR fixes that issue.